### PR TITLE
WIP: Do not assume isoparametricity (iso-parametric-ness?)

### DIFF
--- a/test/test_grudge.py
+++ b/test/test_grudge.py
@@ -251,7 +251,7 @@ def test_2d_gauss_theorem(ctx_factory):
     ])
 @pytest.mark.parametrize("op_type", ["strong", "weak"])
 @pytest.mark.parametrize("flux_type", ["central"])
-@pytest.mark.parametrize("order", [3, 4, 5])
+@pytest.mark.parametrize("order", [0, 3, 4, 5])
 # test: 'test_convergence_advec(cl._csc, "disk", [0.1, 0.05], "strong", "upwind", 3)'
 def test_convergence_advec(ctx_factory, mesh_name, mesh_pars, op_type, flux_type,
         order, visualize=False):
@@ -269,7 +269,7 @@ def test_convergence_advec(ctx_factory, mesh_name, mesh_pars, op_type, flux_type
             from meshmode.mesh.generation import generate_box_mesh
             mesh = generate_box_mesh(
                 [np.linspace(-1.0, 1.0, mesh_par)],
-                order=order)
+                order=1)
 
             dim = 1
             dt_factor = 1.0
@@ -341,7 +341,7 @@ def test_convergence_advec(ctx_factory, mesh_name, mesh_pars, op_type, flux_type
             final_time = 0.2
 
         h_max = bind(discr, sym.h_max_from_volume(discr.ambient_dim))(actx)
-        dt = dt_factor * h_max/order**2
+        dt = dt_factor * h_max/max(order, 1)**2
         nsteps = (final_time // dt) + 1
         dt = final_time/nsteps + 1e-15
 

--- a/test/test_grudge.py
+++ b/test/test_grudge.py
@@ -255,7 +255,7 @@ def test_2d_gauss_theorem(ctx_factory):
 # test: 'test_convergence_advec(cl._csc, "disk", [0.1, 0.05], "strong", "upwind", 3)'
 def test_convergence_advec(ctx_factory, mesh_name, mesh_pars, op_type, flux_type,
         order, visualize=False):
-    """Test whether 2D advection actually converges"""
+    """Test whether advection actually converges"""
 
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)


### PR DESCRIPTION
(IMO) the way that this should go is that the there should be a separate meshmode `Discretization` in `DGDiscretizationWithBoundaries` to capture geometry info. This discretization would then be used to compute geometry-related info, such as metric derivatives and area/surface elements. It should be straightforward to handle this by introducing a separate `quadrature_tag` (which this reveals to be mis-named, ugh).

The net benefit of this would be to enable order 0 DG (aka finite volume). It's needed because order 0 (one DOF per triangle, i.e. strictly isoparametric) doesn't do great at representing triangles. But we may like running subparametrically anyhow. For example, this permits a very easy way of "sectioning off" affinely-transformed element groups from ones that have non-affine mappings, where geometry calculations (and mass matrix inversions, even with WADG) are cheaper on affinely transformed elements.

NB: This sits on top array context work, which lives
- [here](https://gitlab.tiker.net/inducer/meshmode/-/merge_requests/80) in meshmode
- [here](https://gitlab.tiker.net/inducer/grudge/-/merge_requests/71) in grudge
so it should merge after those.

cc @lukeolson @mtcam @alexfikl 