### PR TITLE
Fix wave-eager* example signs

### DIFF
--- a/examples/wave/wave-eager-mpi.py
+++ b/examples/wave/wave-eager-mpi.py
@@ -60,7 +60,7 @@ def wave_flux(discr, c, w_tpair):
 
     # upwind
     v_jump = np.dot(normal, v.int-v.ext)
-    flux_weak -= flat_obj_array(
+    flux_weak += flat_obj_array(
             0.5*(u.int-u.ext),
             0.5*normal*scalar(v_jump),
             )
@@ -80,10 +80,10 @@ def wave_operator(discr, c, w):
     return (
             discr.inverse_mass(
                 flat_obj_array(
-                    c*discr.weak_div(v),
-                    c*discr.weak_grad(u)
+                    -c*discr.weak_div(v),
+                    -c*discr.weak_grad(u)
                     )
-                -  # noqa: W504
+                +  # noqa: W504
                 discr.face_mass(
                     wave_flux(discr, c=c, w_tpair=interior_trace_pair(discr, w))
                     + wave_flux(discr, c=c, w_tpair=TracePair(

--- a/examples/wave/wave-eager-var-velocity.py
+++ b/examples/wave/wave-eager-var-velocity.py
@@ -61,12 +61,12 @@ def wave_flux(discr, c, w_tpair):
 
     # upwind
     v_jump = np.dot(normal, v.int-v.ext)
-    flux_weak -= flat_obj_array(
+    flux_weak += flat_obj_array(
             0.5*(u.int-u.ext),
             0.5*normal*scalar(v_jump),
             )
 
-    # FIMXE this flux is only correct for continuous c
+    # FIXME this flux is only correct for continuous c
     dd_allfaces_quad = dd_quad.with_dtag("all_faces")
     c_quad = discr.project("vol", dd_quad, c)
     flux_quad = discr.project(dd, dd_quad, flux_weak)
@@ -91,14 +91,13 @@ def wave_operator(discr, c, w):
 
     dd_allfaces_quad = DOFDesc("all_faces", "vel_prod")
 
-    # FIXME Fix sign issue
     return (
             discr.inverse_mass(
                 flat_obj_array(
-                    discr.weak_div(dd_quad, scalar(c_quad)*v_quad),
-                    discr.weak_grad(dd_quad, c_quad*u_quad)
+                    -discr.weak_div(dd_quad, scalar(c_quad)*v_quad),
+                    -discr.weak_grad(dd_quad, c_quad*u_quad)
                     )
-                -  # noqa: W504
+                +  # noqa: W504
                 discr.face_mass(
                     dd_allfaces_quad,
                     wave_flux(discr, c=c, w_tpair=interior_trace_pair(discr, w))

--- a/examples/wave/wave-eager.py
+++ b/examples/wave/wave-eager.py
@@ -58,7 +58,7 @@ def wave_flux(discr, c, w_tpair):
 
     # upwind
     v_jump = np.dot(normal, v.int-v.ext)
-    flux_weak -= flat_obj_array(
+    flux_weak += flat_obj_array(
             0.5*(u.int-u.ext),
             0.5*normal*scalar(v_jump),
             )
@@ -78,10 +78,10 @@ def wave_operator(discr, c, w):
     return (
             discr.inverse_mass(
                 flat_obj_array(
-                    c*discr.weak_div(v),
-                    c*discr.weak_grad(u)
+                    -c*discr.weak_div(v),
+                    -c*discr.weak_grad(u)
                     )
-                -  # noqa: W504
+                +  # noqa: W504
                 discr.face_mass(
                     wave_flux(discr, c=c, w_tpair=interior_trace_pair(discr, w))
                     + wave_flux(discr, c=c, w_tpair=TracePair(


### PR DESCRIPTION
Sorry, I kept forgetting about this. 🙂 

I ran each example before and after the changes, and the results seem to be as expected (i.e., still stable, `u` unchanged, `v` different by a minus sign).