### PR TITLE
Fix object array vectorization in interior_trace_pair

### DIFF
--- a/grudge/eager.py
+++ b/grudge/eager.py
@@ -341,12 +341,7 @@ class EagerDGDiscretization(DGDiscretizationWithBoundaries):
 
 def interior_trace_pair(discrwb, vec):
     i = discrwb.project("vol", "int_faces", vec)
-
-    if isinstance(vec, np.ndarray):
-        e = obj_array_vectorize(
-                lambda el: discrwb.opposite_face_connection()(el),
-                i)
-
+    e = obj_array_vectorize(lambda el: discrwb.opposite_face_connection()(el), i)
     return TracePair("int_faces", interior=i, exterior=e)
 
 


### PR DESCRIPTION
Fixes scalar case (previously missing "else" condition").

Tested in illinois-ceesd/mirgecom#128