### PR TITLE
Add mass operator to EagerDGDiscretization

### DIFF
--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -266,7 +266,8 @@ class DGDiscretizationWithBoundaries:
                         make_same_mesh_connection
                 to_discr = self._quad_volume_discr(to_dd.quadrature_tag)
                 from_discr = self._volume_discr
-                return make_same_mesh_connection(to_discr, from_discr)
+                return make_same_mesh_connection(self._setup_actx, to_discr,
+                            from_discr)
 
             else:
                 raise ValueError("cannot interpolate from volume to: " + str(to_dd))

--- a/grudge/eager.py
+++ b/grudge/eager.py
@@ -83,6 +83,9 @@ class EagerDGDiscretization(DGDiscretizationWithBoundaries):
         :arg tgt: a :class:`~grudge.sym.DOFDesc`, or a value convertible to one
         :arg vec: a :class:`~meshmode.dof_array.DOFArray`
         """
+        if src == tgt:
+            return vec
+
         if isinstance(vec, np.ndarray):
             return obj_array_vectorize(
                     lambda el: self.project(src, tgt, el), vec)

--- a/grudge/eager.py
+++ b/grudge/eager.py
@@ -84,6 +84,8 @@ class EagerDGDiscretization(DGDiscretizationWithBoundaries):
         :arg tgt: a :class:`~grudge.sym.DOFDesc`, or a value convertible to one
         :arg vec: a :class:`~meshmode.dof_array.DOFArray`
         """
+        src = sym.as_dofdesc(src)
+        tgt = sym.as_dofdesc(tgt)
         if src == tgt:
             return vec
 

--- a/grudge/symbolic/operators.py
+++ b/grudge/symbolic/operators.py
@@ -486,7 +486,7 @@ class MassOperatorBase(Operator):
         if dd_in is None:
             dd_in = prim.DD_VOLUME
         if dd_out is None:
-            dd_out = dd_in
+            dd_out = prim.DD_VOLUME
 
         super().__init__(dd_in, dd_out)
 
@@ -705,7 +705,7 @@ def integral(arg, dd=None):
 
     return NodalSum(dd)(
             arg * prim.cse(
-                MassOperator(dd_in=dd)(prim.Ones(dd)),
+                MassOperator(dd_in=dd, dd_out=dd)(prim.Ones(dd)),
                 "mass_quad_weights",
                 prim.cse_scope.DISCRETIZATION))
 
@@ -764,7 +764,7 @@ def h_max_from_volume(ambient_dim, dim=None, dd=None):
 
     return NodalMax(dd_in=dd)(
             ElementwiseSumOperator(dd)(
-                MassOperator(dd_in=dd)(prim.Ones(dd))
+                MassOperator(dd_in=dd, dd_out=dd)(prim.Ones(dd))
                 )
             )**(1.0/dim)
 
@@ -785,7 +785,7 @@ def h_min_from_volume(ambient_dim, dim=None, dd=None):
 
     return NodalMin(dd_in=dd)(
             ElementwiseSumOperator(dd)(
-                MassOperator(dd_in=dd)(prim.Ones(dd))
+                MassOperator(dd_in=dd, dd_out=dd)(prim.Ones(dd))
                 )
             )**(1.0/dim)
 


### PR DESCRIPTION
Adds a `mass()` operator method to `EagerDGDiscretization` (and fixes a couple of little bugs).