### PR TITLE
Handle projection of constants

### DIFF
--- a/grudge/eager.py
+++ b/grudge/eager.py
@@ -33,6 +33,7 @@ from meshmode.dof_array import freeze, flatten, unflatten
 from grudge.discretization import DGDiscretizationWithBoundaries
 from grudge.symbolic.primitives import TracePair
 
+from numbers import Number
 
 __doc__ = """
 .. autoclass:: EagerDGDiscretization
@@ -92,6 +93,9 @@ class EagerDGDiscretization(DGDiscretizationWithBoundaries):
         if isinstance(vec, np.ndarray):
             return obj_array_vectorize(
                     lambda el: self.project(src, tgt, el), vec)
+
+        if isinstance(vec, Number):
+            return vec
 
         return self.connection_from_dds(src, tgt)(vec)
 


### PR DESCRIPTION
Tested in illinois-ceesd/mirgecom#180.

Seems to work, though it's maybe a little bit crude. It bypasses some of the from/to compatibility checks in `connection_from_dds`; I could implement this inside `connection_from_dds` instead, but I think then I would need to define a new connection type to return?