### PR TITLE
Remove hwloc=1 version constraint in .test-conda-env-py3.yml

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -5,11 +5,7 @@ channels:
 dependencies:
 - git
 - numpy
-
-# to avoid conflict with system openmpi's libhwloc
-- libhwloc=1
 - pocl
-
 - islpy
 - pyopencl
 - python=3


### PR DESCRIPTION
To fix MPI/pocl hwloc conflicts like https://github.com/inducer/grudge/runs/1781132172?check_suite_focus=true.

- [ ] Sister MR: https://gitlab.tiker.net/inducer/grudge/-/merge_requests/95

cc @majosm 