### PR TITLE
Enable comm of 2d arrays in cross_rank_pairs

### DIFF
--- a/grudge/op.py
+++ b/grudge/op.py
@@ -478,9 +478,9 @@ def _cross_rank_trace_pairs_scalar_field(dcoll, vec, tag=None):
 
 
 def cross_rank_trace_pairs(dcoll, ary, tag=None):
-    r"""Get a list of *vec* trace pairs for each partition boundary.
+    r"""Get a list of *ary* trace pairs for each partition boundary.
 
-    For each partition boundary, the field data values in *vec* are
+    For each partition boundary, the field data values in *ary* are
     communicated to/from the neighboring partition. Presumably, this
     communication is MPI (but strictly speaking, may not be, and this
     routine is agnostic to the underlying communication, see e.g.
@@ -489,15 +489,15 @@ def cross_rank_trace_pairs(dcoll, ary, tag=None):
     For each face on each partition boundary, a :class:`TracePair` is
     created with the locally, and remotely owned partition boundary face
     data as the `internal`, and `external` components, respectively.
-    Each of the TracePair components are structured like *vec*.
+    Each of the TracePair components are structured like *ary*.
 
-    The input field data *vec* may be a single
+    The input field data *ary* may be a single
     :class:`~meshmode.dof_array.DOFArray`, or an object
     array of ``DOFArray``\ s of arbitrary shape.
     """
-    if isinstance(vec, np.ndarray):
-        oshape = vec.shape
-        comm_vec = vec.flatten()
+    if isinstance(ary, np.ndarray):
+        oshape = ary.shape
+        comm_vec = ary.flatten()
 
         n, = comm_vec.shape
         result = {}
@@ -520,7 +520,7 @@ def cross_rank_trace_pairs(dcoll, ary, tag=None):
                 )
             for remote_rank in connected_ranks(dcoll)]
     else:
-        return _cross_rank_trace_pairs_scalar_field(dcoll, vec, tag=tag)
+        return _cross_rank_trace_pairs_scalar_field(dcoll, ary, tag=tag)
 
 # }}}
 

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -481,13 +481,13 @@ def cross_rank_trace_pairs(dcoll, vec, tag=None):
     """Get a list of *vec* trace pairs for each partition boundary.
 
     For each partition boundary, the field data values in *vec* are
-    communicated to/from the neighboring partition. Presumably, this 
+    communicated to/from the neighboring partition. Presumably, this
     communication is MPI (but strictly speaking, may not be, and this
     routine is agnostic to the underlying communication, see e.g.
     _cross_rank_trace_pairs_scalar_field).
 
     For each face on each partition boundary, a :class:`TracePair` is
-    created with the locally, and remote owned partition boundary face 
+    created with the locally, and remote owned partition boundary face
     data as the `internal`, and `external` components, respectively.
     Each of the TracePair components are structured like *vec*.
 

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -492,8 +492,8 @@ def cross_rank_trace_pairs(dcoll, vec, tag=None):
     Each of the TracePair components are structured like *vec*.
 
     The input field data *vec* may be an array up to shape like (n, m).
-    *vec* may be a scalar(single) DOFArray (i.e. (n,m)=(1,1)), or an
-    $n \times m$ object array of DOFArrays.
+    *vec* may be a scalar(single) DOFArray, an n-vector of DOFArrays,
+    or an $n \times m$ object array of DOFArrays.
 
     Each of n*m components are independently communicated by calling
     this routine. Upon entry, *vec* is serialized (if needed), each

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -477,8 +477,8 @@ def _cross_rank_trace_pairs_scalar_field(dcoll, vec, tag=None):
         return [rbcomm.finish() for rbcomm in rbcomms]
 
 
-def cross_rank_trace_pairs(dcoll, vec, tag=None):
-    """Get a list of *vec* trace pairs for each partition boundary.
+def cross_rank_trace_pairs(dcoll, ary, tag=None):
+    r"""Get a list of *vec* trace pairs for each partition boundary.
 
     For each partition boundary, the field data values in *vec* are
     communicated to/from the neighboring partition. Presumably, this
@@ -487,17 +487,13 @@ def cross_rank_trace_pairs(dcoll, vec, tag=None):
     _cross_rank_trace_pairs_scalar_field).
 
     For each face on each partition boundary, a :class:`TracePair` is
-    created with the locally, and remote owned partition boundary face
+    created with the locally, and remotely owned partition boundary face
     data as the `internal`, and `external` components, respectively.
     Each of the TracePair components are structured like *vec*.
 
-    The input field data *vec* may be a single DOFArray, or an object
-    array of DOFArrays. Each of *vec* components are independently
-    communicated by calling this routine. Upon entry, *vec* is
-    serialized (if needed), each component is communicated, then
-    (if needed) the components are de-serialized back to the original
-    structure of *vec*, before returned as TracePairs for each partition
-    boundary.
+    The input field data *vec* may be a single
+    :class:`~meshmode.dof_array.DOFArray`, or an object
+    array of ``DOFArray``\ s of arbitrary shape.
     """
     if isinstance(vec, np.ndarray):
         oshape = vec.shape
@@ -505,6 +501,8 @@ def cross_rank_trace_pairs(dcoll, vec, tag=None):
 
         n, = comm_vec.shape
         result = {}
+        # FIXME: Batch this communication rather than
+        # doing it in sequence.
         for ivec in range(n):
             for rank_tpair in _cross_rank_trace_pairs_scalar_field(
                     dcoll, comm_vec[ivec]):

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -500,25 +500,27 @@ def cross_rank_trace_pairs(dcoll, vec, tag=None):
     boundary.
     """
     if isinstance(vec, np.ndarray):
-        orig_shape = vec.shape
+        oshape = vec.shape
         comm_vec = vec.flatten()
 
-        comm_n, = comm_vec.shape
+        n, = comm_vec.shape
         result = {}
-        for ivec in range(comm_n):
+        for ivec in range(n):
             for rank_tpair in _cross_rank_trace_pairs_scalar_field(
                     dcoll, comm_vec[ivec]):
                 assert isinstance(rank_tpair.dd.domain_tag, sym.DTAG_BOUNDARY)
                 assert isinstance(rank_tpair.dd.domain_tag.tag, BTAG_PARTITION)
                 result[rank_tpair.dd.domain_tag.tag.part_nr, ivec] = rank_tpair
 
-        return [TracePair(
-            dd=sym.as_dofdesc(sym.DTAG_BOUNDARY(BTAG_PARTITION(remote_rank))),
-            interior=make_obj_array([result[remote_rank, i].int
-                                     for i in range(comm_n)]).reshape(orig_shape),
-            exterior=make_obj_array([result[remote_rank, i].ext
-                                     for i in range(comm_n)]).reshape(orig_shape))
-                for remote_rank in connected_ranks(dcoll)]
+        return [
+            TracePair(
+                dd=sym.as_dofdesc(sym.DTAG_BOUNDARY(BTAG_PARTITION(remote_rank))),
+                interior=make_obj_array([
+                    result[remote_rank, i].int for i in range(n)]).reshape(oshape),
+                exterior=make_obj_array([
+                    result[remote_rank, i].ext for i in range(n)]).reshape(oshape)
+                )
+            for remote_rank in connected_ranks(dcoll)]
     else:
         return _cross_rank_trace_pairs_scalar_field(dcoll, vec, tag=tag)
 

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -519,30 +519,27 @@ def cross_rank_trace_pairs(dcoll, vec, tag=None):
                 assert isinstance(rank_tpair.dd.domain_tag.tag, BTAG_PARTITION)
                 result[rank_tpair.dd.domain_tag.tag.part_nr, ivec] = rank_tpair
 
-        int_result = {}
-        ext_result = {}
         pb_tpairs = []
         for remote_rank in connected_ranks(dcoll):
+            int_result = {}
+            ext_result = {}
             for ivec in range(vec_n):
                 if vec.ndim == 2:
-                    int_result[remote_rank, ivec] = (
+                    int_result[ivec] = (
                         make_obj_array([result[remote_rank, ivec*vec_m+i].int
                                         for i in range(vec_m)])
                     )
-                    ext_result[remote_rank, ivec] = (
+                    ext_result[ivec] = (
                         make_obj_array([result[remote_rank, ivec*vec_m+i].ext
                                         for i in range(vec_m)])
                     )
                 else:
-                    int_result[remote_rank, ivec] = result[remote_rank, ivec].int
-                    ext_result[remote_rank, ivec] = result[remote_rank, ivec].ext
-            interior = make_obj_array([int_result[remote_rank, i]
-                                       for i in range(vec_n)])
-            exterior = make_obj_array([ext_result[remote_rank, i]
-                                       for i in range(vec_n)])
+                    int_result[ivec] = result[remote_rank, ivec].int
+                    ext_result[ivec] = result[remote_rank, ivec].ext
             pb_tpairs.append(TracePair(
                 dd=sym.as_dofdesc(sym.DTAG_BOUNDARY(BTAG_PARTITION(remote_rank))),
-                interior=interior, exterior=exterior))
+                interior=make_obj_array([int_result[i] for i in range(vec_n)]),
+                exterior=make_obj_array([ext_result[i] for i in range(vec_n)])))
         return pb_tpairs
     else:
         return _cross_rank_trace_pairs_scalar_field(dcoll, vec, tag=tag)


### PR DESCRIPTION
Upon detection of an object array *vec* input to `cross_rank_trace_pairs`, flatten the input array in order to use the existing infrastructure to communicate the data without modification, then recover the original shape upon formation of the returned TracePairs.

The current implementation "works" for _MIRGE-Com_'s purpose of communicating the 2D array of grad(Q) naturally via a call to `cross_rank_trace_pairs` in [NS PR](https://github.com/illinois-ceesd/mirgecom/pull/298).