### PR TITLE
Do not cache interior nodes

### DIFF
--- a/grudge/execution.py
+++ b/grudge/execution.py
@@ -73,7 +73,15 @@ class ExecutionMapper(mappers.Evaluator,
 
     def map_node_coordinate_component(self, expr):
         discr = self.dcoll.discr_from_dd(expr.dd)
-        return thaw(self.array_context, discr.nodes()[expr.axis])
+        return thaw(self.array_context, discr.nodes(
+            # only save volume nodes or boundary nodes
+            # (but not interior ones, which are likely only used once
+            # to compute the normals)
+            cached=(
+                discr.ambient_dim == discr.dim
+                or expr.dd.is_boundary_or_partition_interface()
+                )
+            )[expr.axis])
 
     def map_grudge_variable(self, expr):
         from numbers import Number

--- a/grudge/execution.py
+++ b/grudge/execution.py
@@ -75,8 +75,8 @@ class ExecutionMapper(mappers.Evaluator,
         discr = self.dcoll.discr_from_dd(expr.dd)
         return thaw(self.array_context, discr.nodes(
             # only save volume nodes or boundary nodes
-            # (but not interior ones, which are likely only used once
-            # to compute the normals)
+            # (but not nodes for interior face discretizations, which are likely only
+            # used once to compute the normals)
             cached=(
                 discr.ambient_dim == discr.dim
                 or expr.dd.is_boundary_or_partition_interface()

--- a/grudge/symbolic/primitives.py
+++ b/grudge/symbolic/primitives.py
@@ -575,10 +575,7 @@ def pseudoscalar(ambient_dim, dim=None, dd=None):
     if dim is None:
         dim = ambient_dim
 
-    return cse(
-        parametrization_derivative(ambient_dim, dim, dd=dd)
-        .project_max_grade(),
-        "pseudoscalar", cse_scope.DISCRETIZATION)
+    return parametrization_derivative(ambient_dim, dim, dd=dd).project_max_grade()
 
 
 def area_element(ambient_dim, dim=None, dd=None):


### PR DESCRIPTION
- [ ] Depends on https://github.com/inducer/meshmode/pull/171.

Together with that, it saves storing ~4 big DOF vectors on the GPU.

This goes towards https://github.com/inducer/grudge/issues/65.

cc @nchristensen