### PR TITLE
Docs: Stop linking to source code from docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
     "sphinx_copybutton",
 ]
 


### PR DESCRIPTION
As of https://github.com/inducer/grudge/pull/74, there might actually be something resembling adequate documentation so that we don't need the sad excuse of "just go look at the source".

@thomasgibson What do you think?