### PR TITLE
Grudge Refactoring

### DIFF
--- a/doc/operators.rst
+++ b/doc/operators.rst
@@ -1,5 +1,16 @@
-Discontinuous Galerkin Operators
+Discontinuous Galerkin operators
 ================================
 
 .. automodule:: grudge.op
 .. automodule:: grudge.trace_pair
+
+
+Transfering data between discretizations
+========================================
+
+.. automodule:: grudge.projection
+
+Reductions
+==========
+
+.. automodule:: grudge.reductions

--- a/examples/advection/surface.py
+++ b/examples/advection/surface.py
@@ -172,7 +172,7 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
     # {{{ Surface advection operator
 
     # velocity field
-    x = thaw(op.nodes(dcoll), actx)
+    x = thaw(dcoll.nodes(), actx)
     c = make_obj_array([-x[1], x[0], 0.0])[:dim]
 
     def f_initial_condition(x):
@@ -234,7 +234,7 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
 
         df = dof_desc.DOFDesc(FACE_RESTR_INTERIOR)
         face_discr = dcoll.discr_from_dd(df)
-        face_normal = thaw(op.normal(dcoll, dd=df), actx)
+        face_normal = thaw(dcoll.normal(dd=df), actx)
 
         from meshmode.discretization.visualization import make_visualizer
         vis = make_visualizer(actx, face_discr)

--- a/examples/advection/var-velocity.py
+++ b/examples/advection/var-velocity.py
@@ -169,7 +169,7 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
 
     from grudge.models.advection import VariableCoefficientAdvectionOperator
 
-    x = thaw(op.nodes(dcoll), actx)
+    x = thaw(dcoll.nodes(), actx)
 
     # velocity field
     if dim == 1:

--- a/examples/advection/weak.py
+++ b/examples/advection/weak.py
@@ -152,13 +152,13 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
         dcoll,
         c,
         inflow_u=lambda t: u_analytic(
-            thaw(op.nodes(dcoll, dd=BTAG_ALL), actx),
+            thaw(dcoll.nodes(dd=BTAG_ALL), actx),
             t=t
         ),
         flux_type=flux_type
     )
 
-    nodes = thaw(op.nodes(dcoll), actx)
+    nodes = thaw(dcoll.nodes(), actx)
     u = u_analytic(nodes, t=0)
 
     def rhs(t, u):

--- a/examples/geometry.py
+++ b/examples/geometry.py
@@ -32,8 +32,6 @@ import pyopencl.tools as cl_tools
 
 from arraycontext import PyOpenCLArrayContext, thaw
 
-import grudge.op as op
-
 from grudge import DiscretizationCollection, shortcuts
 
 

--- a/examples/geometry.py
+++ b/examples/geometry.py
@@ -51,9 +51,9 @@ def main(write_output=True):
 
     dcoll = DiscretizationCollection(actx, mesh, order=4)
 
-    nodes = thaw(op.nodes(dcoll), actx)
-    bdry_nodes = thaw(op.nodes(dcoll, dd=BTAG_ALL), actx)
-    bdry_normals = thaw(op.normal(dcoll, dd=BTAG_ALL), actx)
+    nodes = thaw(dcoll.nodes(), actx)
+    bdry_nodes = thaw(dcoll.nodes(dd=BTAG_ALL), actx)
+    bdry_normals = thaw(dcoll.normal(dd=BTAG_ALL), actx)
 
     if write_output:
         vis = shortcuts.make_visualizer(dcoll)

--- a/examples/maxwell/cavities.py
+++ b/examples/maxwell/cavities.py
@@ -84,7 +84,7 @@ def main(ctx_factory, dim=3, order=4, visualize=False):
         else:
             return get_rectangular_cavity_mode(actx, x, t, 1, (2, 3))
 
-    fields = cavity_mode(thaw(op.nodes(dcoll), actx), t=0)
+    fields = cavity_mode(thaw(dcoll.nodes(), actx), t=0)
 
     maxwell_operator.check_bc_coverage(mesh)
 

--- a/examples/wave/var-propagation-speed.py
+++ b/examples/wave/var-propagation-speed.py
@@ -63,7 +63,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]
         source_width = 0.05
         source_omega = 3
-        nodes = thaw(op.nodes(dcoll), actx)
+        nodes = thaw(dcoll.nodes(), actx)
         source_center_dist = flat_obj_array(
             [nodes[i] - source_center[i] for i in range(dcoll.dim)]
         )
@@ -75,7 +75,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
             )
         )
 
-    x = thaw(op.nodes(dcoll), actx)
+    x = thaw(dcoll.nodes(), actx)
     ones = dcoll.zeros(actx) + 1
     c = actx.np.where(np.dot(x, x) < 0.15, 0.1 * ones, 0.2 * ones)
 

--- a/examples/wave/wave-min-mpi.py
+++ b/examples/wave/wave-min-mpi.py
@@ -84,7 +84,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]
         source_width = 0.05
         source_omega = 3
-        nodes = thaw(op.nodes(dcoll), actx)
+        nodes = thaw(dcoll.nodes(), actx)
         source_center_dist = flat_obj_array(
             [nodes[i] - source_center[i] for i in range(dcoll.dim)]
         )

--- a/examples/wave/wave-min.py
+++ b/examples/wave/wave-min.py
@@ -65,7 +65,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]
         source_width = 0.05
         source_omega = 3
-        nodes = thaw(op.nodes(dcoll), actx)
+        nodes = thaw(dcoll.nodes(), actx)
         source_center_dist = flat_obj_array(
             [nodes[i] - source_center[i] for i in range(dcoll.dim)]
         )

--- a/examples/wave/wave-op-mpi.py
+++ b/examples/wave/wave-op-mpi.py
@@ -54,7 +54,7 @@ def wave_flux(dcoll, c, w_tpair):
     u = w_tpair[0]
     v = w_tpair[1:]
 
-    normal = thaw(op.normal(dcoll, w_tpair.dd), u.int.array_context)
+    normal = thaw(dcoll.normal(w_tpair.dd), u.int.array_context)
 
     flux_weak = flat_obj_array(
             np.dot(v.avg, normal),
@@ -136,7 +136,7 @@ def bump(actx, dcoll, t=0):
     source_width = 0.05
     source_omega = 3
 
-    nodes = thaw(op.nodes(dcoll), actx)
+    nodes = thaw(dcoll.nodes(), actx)
     center_dist = flat_obj_array([
         nodes[i] - source_center[i]
         for i in range(dcoll.dim)

--- a/examples/wave/wave-op-var-velocity.py
+++ b/examples/wave/wave-op-var-velocity.py
@@ -56,7 +56,7 @@ def wave_flux(dcoll, c, w_tpair):
     u = w_tpair[0]
     v = w_tpair[1:]
 
-    normal = thaw(op.normal(dcoll, dd), u.int.array_context)
+    normal = thaw(dcoll.normal(dd), u.int.array_context)
 
     flux_weak = flat_obj_array(
             np.dot(v.avg, normal),
@@ -146,7 +146,7 @@ def bump(actx, dcoll, t=0, width=0.05, center=None):
     center = center[:dcoll.dim]
     source_omega = 3
 
-    nodes = thaw(op.nodes(dcoll), actx)
+    nodes = thaw(dcoll.nodes(), actx)
     center_dist = flat_obj_array([
         nodes[i] - center[i]
         for i in range(dcoll.dim)

--- a/examples/wave/wave-op.py
+++ b/examples/wave/wave-op.py
@@ -52,7 +52,7 @@ def wave_flux(dcoll, c, w_tpair):
     u = w_tpair[0]
     v = w_tpair[1:]
 
-    normal = thaw(op.normal(dcoll, w_tpair.dd), u.int.array_context)
+    normal = thaw(dcoll.normal(w_tpair.dd), u.int.array_context)
 
     flux_weak = flat_obj_array(
             np.dot(v.avg, normal),
@@ -127,7 +127,7 @@ def bump(actx, dcoll, t=0):
     source_width = 0.05
     source_omega = 3
 
-    nodes = thaw(op.nodes(dcoll), actx)
+    nodes = thaw(dcoll.nodes(), actx)
     center_dist = flat_obj_array([
         nodes[i] - source_center[i]
         for i in range(dcoll.dim)

--- a/grudge/interpolation.py
+++ b/grudge/interpolation.py
@@ -1,0 +1,46 @@
+"""
+Interpolation
+-------------
+
+.. autofunction:: interp
+"""
+
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+from grudge.discretization import DiscretizationCollection
+
+
+# FIXME: Should revamp interp and make clear distinctions
+# between projection and interpolations.
+# Related issue: https://github.com/inducer/grudge/issues/38
+def interp(dcoll: DiscretizationCollection, src, tgt, vec):
+    from warnings import warn
+    warn("'interp' currently calls to 'project'",
+         UserWarning, stacklevel=2)
+
+    from grudge.projection import project
+
+    return project(dcoll, src, tgt, vec)

--- a/grudge/interpolation.py
+++ b/grudge/interpolation.py
@@ -1,4 +1,6 @@
 """
+.. currentmodule:: grudge.op
+
 Interpolation
 -------------
 

--- a/grudge/models/advection.py
+++ b/grudge/models/advection.py
@@ -43,7 +43,7 @@ def advection_weak_flux(dcoll, flux_type, u_tpair, velocity):
     """
     actx = u_tpair.int.array_context
     dd = u_tpair.dd
-    normal = thaw(op.normal(dcoll, dd), actx)
+    normal = thaw(dcoll.normal(dd), actx)
     v_dot_n = np.dot(velocity, normal)
 
     flux_type = flux_type.lower()
@@ -92,7 +92,7 @@ class StrongAdvectionOperator(AdvectionOperatorBase):
     def flux(self, u_tpair):
         actx = u_tpair.int.array_context
         dd = u_tpair.dd
-        normal = thaw(op.normal(self.dcoll, dd), actx)
+        normal = thaw(self.dcoll.normal(dd), actx)
         v_dot_normal = np.dot(self.v, normal)
 
         return u_tpair.int * v_dot_normal - self.weak_flux(u_tpair)
@@ -285,7 +285,7 @@ def v_dot_n_tpair(actx, dcoll, velocity, trace_dd):
     from grudge.trace_pair import TracePair
     from meshmode.discretization.connection import FACE_RESTR_INTERIOR
 
-    normal = thaw(op.normal(dcoll, trace_dd.with_discr_tag(None)), actx)
+    normal = thaw(dcoll.normal(trace_dd.with_discr_tag(None)), actx)
     v_dot_n = velocity.dot(normal)
     i = op.project(dcoll, trace_dd.with_discr_tag(None), trace_dd, v_dot_n)
 

--- a/grudge/models/em.py
+++ b/grudge/models/em.py
@@ -120,7 +120,7 @@ class MaxwellOperator(HyperbolicOperator):
         As per Hesthaven and Warburton page 433.
         """
 
-        normal = thaw(op.normal(self.dcoll, wtpair.dd), self.dcoll._setup_actx)
+        normal = thaw(self.dcoll.normal(wtpair.dd), self.dcoll._setup_actx)
 
         if self.fixed_material:
             e, h = self.split_eh(wtpair)
@@ -220,7 +220,7 @@ class MaxwellOperator(HyperbolicOperator):
         absorbing boundary conditions.
         """
 
-        absorb_normal = thaw(op.normal(self.dcoll, dd=self.absorb_tag),
+        absorb_normal = thaw(self.dcoll.normal(dd=self.absorb_tag),
                              self.dcoll._setup_actx)
 
         e, h = self.split_eh(w)

--- a/grudge/models/wave.py
+++ b/grudge/models/wave.py
@@ -90,7 +90,7 @@ class WeakWaveOperator(HyperbolicOperator):
         u = wtpair[0]
         v = wtpair[1:]
         actx = u.int.array_context
-        normal = thaw(op.normal(self.dcoll, wtpair.dd), actx)
+        normal = thaw(self.dcoll.normal(wtpair.dd), actx)
 
         central_flux_weak = -self.c*flat_obj_array(
                 np.dot(v.avg, normal),
@@ -133,7 +133,7 @@ class WeakWaveOperator(HyperbolicOperator):
         neu_bc = flat_obj_array(neu_u, -neu_v)
 
         # radiation BCs -------------------------------------------------------
-        rad_normal = thaw(op.normal(dcoll, dd=self.radiation_tag), actx)
+        rad_normal = thaw(dcoll.normal(dd=self.radiation_tag), actx)
 
         rad_u = op.project(dcoll, "vol", self.radiation_tag, u)
         rad_v = op.project(dcoll, "vol", self.radiation_tag, v)
@@ -233,7 +233,7 @@ class VariableCoefficientWeakWaveOperator(HyperbolicOperator):
         u = wtpair[1]
         v = wtpair[2:]
         actx = u.int.array_context
-        normal = thaw(op.normal(self.dcoll, wtpair.dd), actx)
+        normal = thaw(self.dcoll.normal(wtpair.dd), actx)
 
         flux_central_weak = -0.5 * flat_obj_array(
             np.dot(v.int*c.int + v.ext*c.ext, normal),
@@ -282,7 +282,7 @@ class VariableCoefficientWeakWaveOperator(HyperbolicOperator):
         neu_bc = flat_obj_array(neu_c, neu_u, -neu_v)
 
         # radiation BCs -------------------------------------------------------
-        rad_normal = thaw(op.normal(dcoll, dd=self.radiation_tag), actx)
+        rad_normal = thaw(dcoll.normal(dd=self.radiation_tag), actx)
 
         rad_c = op.project(dcoll, "vol", self.radiation_tag, self.c)
         rad_u = op.project(dcoll, "vol", self.radiation_tag, u)

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -50,8 +50,6 @@ THE SOFTWARE.
 """
 
 
-from numbers import Number
-
 from arraycontext import (
     ArrayContext,
     FirstAxisIsElementsTag,

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -1,20 +1,4 @@
 """
-Data transfer and geometry
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Projection and interpolation
-----------------------------
-
-.. autofunction:: project
-
-Geometric quantities
---------------------
-
-.. autofunction:: nodes
-.. autofunction:: normal
-.. autofunction:: h_max_from_volume
-.. autofunction:: h_min_from_volume
-
 Core DG routines
 ^^^^^^^^^^^^^^^^
 
@@ -38,24 +22,6 @@ Mass, inverse mass, and face mass operators
 .. autofunction:: mass
 .. autofunction:: inverse_mass
 .. autofunction:: face_mass
-
-Support functions
-^^^^^^^^^^^^^^^^^
-
-Nodal reductions
-----------------
-
-.. autofunction:: norm
-.. autofunction:: nodal_sum
-.. autofunction:: nodal_min
-.. autofunction:: nodal_max
-.. autofunction:: integral
-
-Elementwise reductions
-----------------------
-
-.. autofunction:: elementwise_sum
-.. autofunction:: elementwise_integral
 """
 
 __copyright__ = """
@@ -85,7 +51,6 @@ THE SOFTWARE.
 
 
 from numbers import Number
-from functools import reduce
 
 from arraycontext import (
     ArrayContext,
@@ -95,19 +60,29 @@ from arraycontext import (
 
 from grudge.discretization import DiscretizationCollection
 
-from pytools import (
-    memoize_in,
-    memoize_on_first_arg,
-    keyed_memoize_in
-)
+from pytools import memoize_in, keyed_memoize_in
 from pytools.obj_array import obj_array_vectorize, make_obj_array
 
 from meshmode.dof_array import DOFArray
 
 import numpy as np
+
 import grudge.dof_desc as dof_desc
 
-from grudge.trace_pair import (  # noqa
+from grudge.interpolation import interp  # noqa: F401
+from grudge.projection import project  # noqa: F401
+
+from grudge.reductions import (  # noqa: F401
+    norm,
+    nodal_sum,
+    nodal_min,
+    nodal_max,
+    integral,
+    elementwise_sum,
+    elementwise_integral,
+)
+
+from grudge.trace_pair import (  # noqa: F401
     interior_trace_pair,
     interior_trace_pairs,
     connected_ranks,
@@ -126,129 +101,6 @@ class HasElementwiseMatvecTag(FirstAxisIsElementsTag):
     the implementation should set element indices as the outermost
     loop extent.
     """
-
-# }}}
-
-
-# {{{ Interpolation and projection
-
-# FIXME: Should reintroduce interp and make clear distinctions
-# between projection and interpolations.
-# Related issue: https://github.com/inducer/grudge/issues/38
-# def interp(dcoll: DiscretizationCollection, src, tgt, vec):
-#     from warnings import warn
-#     warn("using 'interp' is deprecated, use 'project' instead.",
-#          DeprecationWarning, stacklevel=2)
-#
-#     return project(dcoll, src, tgt, vec)
-
-
-def project(dcoll: DiscretizationCollection, src, tgt, vec):
-    """Project from one discretization to another, e.g. from the
-    volume to the boundary, or from the base to the an overintegrated
-    quadrature discretization.
-
-    :arg src: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-    :arg tgt: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray` or a
-        :class:`~arraycontext.ArrayContainer`.
-    """
-    src = dof_desc.as_dofdesc(src)
-    tgt = dof_desc.as_dofdesc(tgt)
-    if src == tgt:
-        return vec
-
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-                lambda el: project(dcoll, src, tgt, el), vec)
-
-    if isinstance(vec, Number):
-        return vec
-
-    return dcoll.connection_from_dds(src, tgt)(vec)
-
-# }}}
-
-
-# {{{ geometric properties
-
-def nodes(dcoll: DiscretizationCollection, dd=None) -> np.ndarray:
-    r"""Return the nodes of a discretization.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-        Defaults to the base volume discretization.
-    :returns: an object array of :class:`~meshmode.dof_array.DOFArray`\ s.
-    """
-    if dd is None:
-        dd = dof_desc.DD_VOLUME
-    dd = dof_desc.as_dofdesc(dd)
-
-    return dcoll.nodes(dd)
-
-
-def normal(dcoll: DiscretizationCollection, dd) -> np.ndarray:
-    r"""Get the unit normal to the specified surface discretization, *dd*.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc` as the surface discretization.
-    :returns: an object array of :class:`~meshmode.dof_array.DOFArray`\ s.
-    """
-    return dcoll.normal(dd)
-
-
-@memoize_on_first_arg
-def h_max_from_volume(dcoll: DiscretizationCollection, dim=None, dd=None):
-    """Returns a (maximum) characteristic length based on the volume of the
-    elements. This length may not be representative if the elements have very
-    high aspect ratios.
-
-    :arg dim: an integer denoting topological dimension. If *None*, the
-        spatial dimension specified by
-        :attr:`grudge.DiscretizationCollection.dim` is used.
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-        Defaults to the base volume discretization if not provided.
-    :returns: a scalar denoting the maximum characteristic length.
-    """
-    if dd is None:
-        dd = dof_desc.DD_VOLUME
-    dd = dof_desc.as_dofdesc(dd)
-
-    if dim is None:
-        dim = dcoll.dim
-
-    ones = dcoll.discr_from_dd(dd).zeros(dcoll._setup_actx) + 1.0
-    return nodal_max(
-        dcoll,
-        dd,
-        elementwise_sum(dcoll, mass(dcoll, dd, ones))
-    ) ** (1.0 / dim)
-
-
-@memoize_on_first_arg
-def h_min_from_volume(dcoll: DiscretizationCollection, dim=None, dd=None):
-    """Returns a (minimum) characteristic length based on the volume of the
-    elements. This length may not be representative if the elements have very
-    high aspect ratios.
-
-    :arg dim: an integer denoting topological dimension. If *None*, the
-        spatial dimension specified by
-        :attr:`grudge.DiscretizationCollection.dim` is used.
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-        Defaults to the base volume discretization if not provided.
-    :returns: a scalar denoting the minimum characteristic length.
-    """
-    if dd is None:
-        dd = dof_desc.DD_VOLUME
-    dd = dof_desc.as_dofdesc(dd)
-
-    if dim is None:
-        dim = dcoll.dim
-
-    ones = dcoll.discr_from_dd(dd).zeros(dcoll._setup_actx) + 1.0
-    return nodal_min(
-        dcoll,
-        dd,
-        elementwise_sum(dcoll, mass(dcoll, dd, ones))
-    ) ** (1.0 / dim)
 
 # }}}
 
@@ -1015,212 +867,6 @@ def face_mass(dcoll: DiscretizationCollection, *args):
         raise TypeError("invalid number of arguments")
 
     return _apply_face_mass_operator(dcoll, dd, vec)
-
-# }}}
-
-
-# {{{ Nodal reductions
-
-def _norm(dcoll: DiscretizationCollection, vec, p, dd):
-    if isinstance(vec, Number):
-        return np.fabs(vec)
-    if p == 2:
-        return np.real_if_close(np.sqrt(
-            nodal_sum(
-                dcoll,
-                dd,
-                vec.conj() * _apply_mass_operator(dcoll, dd, dd, vec)
-            )
-        ))
-    elif p == np.inf:
-        return nodal_max(dcoll, dd, abs(vec))
-    else:
-        raise NotImplementedError("Unsupported value of p")
-
-
-def norm(dcoll: DiscretizationCollection, vec, p, dd=None):
-    r"""Return the vector p-norm of a function represented
-    by its vector of degrees of freedom *vec*.
-
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray` or an object array of
-        a :class:`~meshmode.dof_array.DOFArray`\ s,
-        where the last axis of the array must have length
-        matching the volume dimension.
-    :arg p: an integer denoting the order of the integral norm. Currently,
-        only values of 2 or `numpy.inf` are supported.
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-        Defaults to the base volume discretization if not provided.
-    :returns: a nonegative scalar denoting the norm.
-    """
-    # FIXME: We should make the nodal reductions respect MPI.
-    # See: https://github.com/inducer/grudge/issues/112 and
-    # https://github.com/inducer/grudge/issues/113
-
-    if dd is None:
-        dd = dof_desc.DD_VOLUME
-
-    dd = dof_desc.as_dofdesc(dd)
-
-    if isinstance(vec, np.ndarray):
-        if p == 2:
-            return sum(
-                    norm(dcoll, vec[idx], p, dd=dd)**2
-                    for idx in np.ndindex(vec.shape))**0.5
-        elif p == np.inf:
-            return max(
-                    norm(dcoll, vec[idx], np.inf, dd=dd)
-                    for idx in np.ndindex(vec.shape))
-        else:
-            raise ValueError("unsupported norm order")
-
-    return _norm(dcoll, vec, p, dd)
-
-
-def nodal_sum(dcoll: DiscretizationCollection, dd, vec):
-    r"""Return the nodal sum of a vector of degrees of freedom *vec*.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value
-        convertible to one.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
-    :returns: a scalar denoting the nodal sum.
-    """
-    # FIXME: We should make the nodal reductions respect MPI.
-    # See: https://github.com/inducer/grudge/issues/112 and
-    # https://github.com/inducer/grudge/issues/113
-    actx = vec.array_context
-    return sum([actx.np.sum(grp_ary) for grp_ary in vec])
-
-
-def nodal_min(dcoll: DiscretizationCollection, dd, vec):
-    r"""Return the nodal minimum of a vector of degrees of freedom *vec*.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value
-        convertible to one.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
-    :returns: a scalar denoting the nodal minimum.
-    """
-    # FIXME: We should make the nodal reductions respect MPI.
-    # See: https://github.com/inducer/grudge/issues/112 and
-    # https://github.com/inducer/grudge/issues/113
-    actx = vec.array_context
-    return reduce(lambda acc, grp_ary: actx.np.minimum(acc, actx.np.min(grp_ary)),
-                  vec, np.inf)
-
-
-def nodal_max(dcoll: DiscretizationCollection, dd, vec):
-    r"""Return the nodal maximum of a vector of degrees of freedom *vec*.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value
-        convertible to one.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
-    :returns: a scalar denoting the nodal maximum.
-    """
-    # FIXME: We should make the nodal reductions respect MPI.
-    # See: https://github.com/inducer/grudge/issues/112 and
-    # https://github.com/inducer/grudge/issues/113
-    actx = vec.array_context
-    return reduce(lambda acc, grp_ary: actx.np.maximum(acc, actx.np.max(grp_ary)),
-                  vec, -np.inf)
-
-
-def integral(dcoll: DiscretizationCollection, dd, vec):
-    """Numerically integrates a function represented by a
-    :class:`~meshmode.dof_array.DOFArray` of degrees of freedom.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray`
-    :returns: a scalar denoting the evaluated integral.
-    """
-
-    dd = dof_desc.as_dofdesc(dd)
-
-    ones = dcoll.discr_from_dd(dd).zeros(vec.array_context) + 1.0
-    return nodal_sum(
-        dcoll, dd, vec * _apply_mass_operator(dcoll, dd, dd, ones)
-    )
-
-# }}}
-
-
-# {{{  Elementwise reductions
-
-def _map_elementwise_reduction(actx: ArrayContext, op_name):
-    @memoize_in(actx, (_map_elementwise_reduction,
-                       "elementwise_%s_prg" % op_name))
-    def prg():
-        return make_loopy_program(
-            [
-                "{[iel]: 0 <= iel < nelements}",
-                "{[idof, jdof]: 0 <= idof, jdof < ndofs}"
-            ],
-            """
-                result[iel, idof] = %s(jdof, operand[iel, jdof])
-            """ % op_name,
-            name="grudge_elementwise_%s_knl" % op_name
-        )
-    return prg()
-
-
-def elementwise_sum(dcoll: DiscretizationCollection, *args):
-    r"""Returns a vector of DOFs with all entries on each element set
-    to the sum of DOFs on that element.
-
-    May be called with ``(dcoll, vec)`` or ``(dcoll, dd, vec)``.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-        Defaults to the base volume discretization if not provided.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray`
-    :returns: a :class:`~meshmode.dof_array.DOFArray` whose entries
-        denote the element-wise sum of *vec*.
-    """
-
-    if len(args) == 1:
-        vec, = args
-        dd = dof_desc.DOFDesc("vol", dof_desc.DISCR_TAG_BASE)
-    elif len(args) == 2:
-        dd, vec = args
-    else:
-        raise TypeError("invalid number of arguments")
-
-    dd = dof_desc.as_dofdesc(dd)
-
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-            lambda vi: elementwise_sum(dcoll, dd, vi), vec
-        )
-
-    actx = vec.array_context
-
-    return DOFArray(
-        actx,
-        data=tuple(
-            actx.call_loopy(
-                _map_elementwise_reduction(actx, "sum"),
-                operand=vec_i
-            )["result"]
-            for vec_i in vec
-        )
-    )
-
-
-def elementwise_integral(dcoll: DiscretizationCollection, dd, vec):
-    """Numerically integrates a function represented by a
-    :class:`~meshmode.dof_array.DOFArray` of degrees of freedom in
-    each element of a discretization, given by *dd*.
-
-    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
-    :arg vec: a :class:`~meshmode.dof_array.DOFArray`
-    :returns: a :class:`~meshmode.dof_array.DOFArray` containing the
-        elementwise integral of *vec*, represented as a constant function on each
-        cell.
-    """
-
-    dd = dof_desc.as_dofdesc(dd)
-
-    ones = dcoll.discr_from_dd(dd).zeros(vec.array_context) + 1.0
-    return elementwise_sum(
-        dcoll, dd, vec * _apply_mass_operator(dcoll, dd, dd, ones)
-    )
 
 # }}}
 

--- a/grudge/projection.py
+++ b/grudge/projection.py
@@ -1,0 +1,66 @@
+"""
+Projections
+-----------
+
+.. autofunction:: project
+"""
+
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+import numpy as np
+
+from grudge.discretization import DiscretizationCollection
+from grudge.dof_desc import as_dofdesc
+
+from numbers import Number
+
+from pytools.obj_array import obj_array_vectorize
+
+
+def project(dcoll: DiscretizationCollection, src, tgt, vec):
+    """Project from one discretization to another, e.g. from the
+    volume to the boundary, or from the base to the an overintegrated
+    quadrature discretization.
+
+    :arg src: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
+    :arg tgt: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray` or a
+        :class:`~arraycontext.ArrayContainer`.
+    """
+    src = as_dofdesc(src)
+    tgt = as_dofdesc(tgt)
+
+    if src == tgt:
+        return vec
+
+    if isinstance(vec, np.ndarray):
+        return obj_array_vectorize(
+                lambda el: project(dcoll, src, tgt, el), vec)
+
+    if isinstance(vec, Number):
+        return vec
+
+    return dcoll.connection_from_dds(src, tgt)(vec)

--- a/grudge/projection.py
+++ b/grudge/projection.py
@@ -1,4 +1,6 @@
 """
+.. currentmodule:: grudge.op
+
 Projections
 -----------
 

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -1,6 +1,5 @@
 """
-Reduction operations
-^^^^^^^^^^^^^^^^^^^^
+.. currentmodule:: grudge.op
 
 Nodal reductions
 ----------------

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -1,0 +1,273 @@
+"""
+Reduction operations
+^^^^^^^^^^^^^^^^^^^^
+
+Nodal reductions
+----------------
+
+.. autofunction:: norm
+.. autofunction:: nodal_sum
+.. autofunction:: nodal_min
+.. autofunction:: nodal_max
+.. autofunction:: integral
+
+Elementwise reductions
+----------------------
+
+.. autofunction:: elementwise_sum
+.. autofunction:: elementwise_integral
+"""
+
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+from numbers import Number
+from functools import reduce
+
+from arraycontext import (
+    ArrayContext,
+    make_loopy_program
+)
+
+from grudge.discretization import DiscretizationCollection
+
+from pytools import memoize_in
+from pytools.obj_array import obj_array_vectorize
+
+from meshmode.dof_array import DOFArray
+
+import numpy as np
+import grudge.dof_desc as dof_desc
+
+
+# {{{ Nodal reductions
+
+def _norm(dcoll: DiscretizationCollection, vec, p, dd):
+    if isinstance(vec, Number):
+        return np.fabs(vec)
+    if p == 2:
+        from grudge.op import _apply_mass_operator
+        return np.real_if_close(np.sqrt(
+            nodal_sum(
+                dcoll,
+                dd,
+                vec.conj() * _apply_mass_operator(dcoll, dd, dd, vec)
+            )
+        ))
+    elif p == np.inf:
+        return nodal_max(dcoll, dd, abs(vec))
+    else:
+        raise NotImplementedError("Unsupported value of p")
+
+
+def norm(dcoll: DiscretizationCollection, vec, p, dd=None) -> float:
+    r"""Return the vector p-norm of a function represented
+    by its vector of degrees of freedom *vec*.
+
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray` or an object array of
+        a :class:`~meshmode.dof_array.DOFArray`\ s,
+        where the last axis of the array must have length
+        matching the volume dimension.
+    :arg p: an integer denoting the order of the integral norm. Currently,
+        only values of 2 or `numpy.inf` are supported.
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
+        Defaults to the base volume discretization if not provided.
+    :returns: a nonegative scalar denoting the norm.
+    """
+    # FIXME: We should make the nodal reductions respect MPI.
+    # See: https://github.com/inducer/grudge/issues/112 and
+    # https://github.com/inducer/grudge/issues/113
+
+    if dd is None:
+        dd = dof_desc.DD_VOLUME
+
+    dd = dof_desc.as_dofdesc(dd)
+
+    if isinstance(vec, np.ndarray):
+        if p == 2:
+            return sum(
+                    norm(dcoll, vec[idx], p, dd=dd)**2
+                    for idx in np.ndindex(vec.shape))**0.5
+        elif p == np.inf:
+            return max(
+                    norm(dcoll, vec[idx], np.inf, dd=dd)
+                    for idx in np.ndindex(vec.shape))
+        else:
+            raise ValueError("unsupported norm order")
+
+    return _norm(dcoll, vec, p, dd)
+
+
+def nodal_sum(dcoll: DiscretizationCollection, dd, vec) -> float:
+    r"""Return the nodal sum of a vector of degrees of freedom *vec*.
+
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value
+        convertible to one.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
+    :returns: a scalar denoting the nodal sum.
+    """
+    # FIXME: We should make the nodal reductions respect MPI.
+    # See: https://github.com/inducer/grudge/issues/112 and
+    # https://github.com/inducer/grudge/issues/113
+    actx = vec.array_context
+    return sum([actx.np.sum(grp_ary) for grp_ary in vec])
+
+
+def nodal_min(dcoll: DiscretizationCollection, dd, vec) -> float:
+    r"""Return the nodal minimum of a vector of degrees of freedom *vec*.
+
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value
+        convertible to one.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
+    :returns: a scalar denoting the nodal minimum.
+    """
+    # FIXME: We should make the nodal reductions respect MPI.
+    # See: https://github.com/inducer/grudge/issues/112 and
+    # https://github.com/inducer/grudge/issues/113
+    actx = vec.array_context
+    return reduce(lambda acc, grp_ary: actx.np.minimum(acc, actx.np.min(grp_ary)),
+                  vec, np.inf)
+
+
+def nodal_max(dcoll: DiscretizationCollection, dd, vec) -> float:
+    r"""Return the nodal maximum of a vector of degrees of freedom *vec*.
+
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value
+        convertible to one.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
+    :returns: a scalar denoting the nodal maximum.
+    """
+    # FIXME: We should make the nodal reductions respect MPI.
+    # See: https://github.com/inducer/grudge/issues/112 and
+    # https://github.com/inducer/grudge/issues/113
+    actx = vec.array_context
+    return reduce(lambda acc, grp_ary: actx.np.maximum(acc, actx.np.max(grp_ary)),
+                  vec, -np.inf)
+
+
+def integral(dcoll: DiscretizationCollection, dd, vec) -> float:
+    """Numerically integrates a function represented by a
+    :class:`~meshmode.dof_array.DOFArray` of degrees of freedom.
+
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray`
+    :returns: a scalar denoting the evaluated integral.
+    """
+    from grudge.op import _apply_mass_operator
+
+    dd = dof_desc.as_dofdesc(dd)
+
+    ones = dcoll.discr_from_dd(dd).zeros(vec.array_context) + 1.0
+    return nodal_sum(
+        dcoll, dd, vec * _apply_mass_operator(dcoll, dd, dd, ones)
+    )
+
+# }}}
+
+
+# {{{  Elementwise reductions
+
+def _map_elementwise_reduction(actx: ArrayContext, op_name):
+    @memoize_in(actx, (_map_elementwise_reduction,
+                       "elementwise_%s_prg" % op_name))
+    def prg():
+        return make_loopy_program(
+            [
+                "{[iel]: 0 <= iel < nelements}",
+                "{[idof, jdof]: 0 <= idof, jdof < ndofs}"
+            ],
+            """
+                result[iel, idof] = %s(jdof, operand[iel, jdof])
+            """ % op_name,
+            name="grudge_elementwise_%s_knl" % op_name
+        )
+    return prg()
+
+
+def elementwise_sum(dcoll: DiscretizationCollection, *args) -> DOFArray:
+    r"""Returns a vector of DOFs with all entries on each element set
+    to the sum of DOFs on that element.
+
+    May be called with ``(dcoll, vec)`` or ``(dcoll, dd, vec)``.
+
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
+        Defaults to the base volume discretization if not provided.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray`
+    :returns: a :class:`~meshmode.dof_array.DOFArray` whose entries
+        denote the element-wise sum of *vec*.
+    """
+
+    if len(args) == 1:
+        vec, = args
+        dd = dof_desc.DOFDesc("vol", dof_desc.DISCR_TAG_BASE)
+    elif len(args) == 2:
+        dd, vec = args
+    else:
+        raise TypeError("invalid number of arguments")
+
+    dd = dof_desc.as_dofdesc(dd)
+
+    if isinstance(vec, np.ndarray):
+        return obj_array_vectorize(
+            lambda vi: elementwise_sum(dcoll, dd, vi), vec
+        )
+
+    actx = vec.array_context
+
+    return DOFArray(
+        actx,
+        data=tuple(
+            actx.call_loopy(
+                _map_elementwise_reduction(actx, "sum"),
+                operand=vec_i
+            )["result"]
+            for vec_i in vec
+        )
+    )
+
+
+def elementwise_integral(dcoll: DiscretizationCollection, dd, vec) -> DOFArray:
+    """Numerically integrates a function represented by a
+    :class:`~meshmode.dof_array.DOFArray` of degrees of freedom in
+    each element of a discretization, given by *dd*.
+
+    :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray`
+    :returns: a :class:`~meshmode.dof_array.DOFArray` containing the
+        elementwise integral if *vec*.
+    """
+    from grudge.op import _apply_mass_operator
+
+    dd = dof_desc.as_dofdesc(dd)
+
+    ones = dcoll.discr_from_dd(dd).zeros(vec.array_context) + 1.0
+    return elementwise_sum(
+        dcoll, dd, vec * _apply_mass_operator(dcoll, dd, dd, ones)
+    )
+
+# }}}
+
+
+# vim: foldmethod=marker

--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -1,3 +1,25 @@
+"""
+Trace Pairs
+^^^^^^^^^^^
+
+Container class
+---------------
+
+.. autoclass:: TracePair
+
+Boundary trace functions
+------------------------
+
+.. autofunction:: bdry_trace_pair
+.. autofunction:: bv_trace_pair
+
+Interior and cross-rank trace functions
+---------------------------------------
+
+.. autofunction:: interior_trace_pairs
+.. autofunction:: cross_rank_trace_pairs
+"""
+
 __copyright__ = """
 Copyright (C) 2021 University of Illinois Board of Trustees
 """
@@ -43,29 +65,6 @@ from meshmode.mesh import BTAG_PARTITION
 
 import numpy as np
 import grudge.dof_desc as dof_desc
-
-
-__doc__ = """
-Trace Pairs
-^^^^^^^^^^^
-
-Container class
----------------
-
-.. autoclass:: TracePair
-
-Boundary trace functions
-------------------------
-
-.. autofunction:: bdry_trace_pair
-.. autofunction:: bv_trace_pair
-
-Interior and cross-rank trace functions
----------------------------------------
-
-.. autofunction:: interior_trace_pairs
-.. autofunction:: cross_rank_trace_pairs
-"""
 
 
 # {{{ Trace pair container class

--- a/test/test_mpi_communication.py
+++ b/test/test_mpi_communication.py
@@ -76,7 +76,7 @@ def simple_mpi_communication_entrypoint():
     dcoll = DiscretizationCollection(actx, local_mesh, order=5,
             mpi_communicator=comm)
 
-    x = thaw(op.nodes(dcoll), actx)
+    x = thaw(dcoll.nodes(), actx)
     myfunc = actx.np.sin(np.dot(x, [2, 3]))
 
     from grudge.dof_desc import as_dofdesc
@@ -147,7 +147,7 @@ def mpi_communication_entrypoint():
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]
         source_width = 0.05
         source_omega = 3
-        nodes = thaw(op.nodes(dcoll), actx)
+        nodes = thaw(dcoll.nodes(), actx)
         source_center_dist = flat_obj_array(
             [nodes[i] - source_center[i] for i in range(dcoll.dim)]
         )

--- a/test/test_op.py
+++ b/test/test_op.py
@@ -88,7 +88,7 @@ def test_gradient(actx_factory, form, dim, order, vectorize, nested,
             result[dim-1] = result[dim-1] * (-np.pi/2*actx.np.sin(np.pi/2*x[dim-1]))
             return result
 
-        x = thaw(op.nodes(dcoll), actx)
+        x = thaw(dcoll.nodes(), actx)
 
         if vectorize:
             u = make_obj_array([(i+1)*f(x) for i in range(dim)])
@@ -98,7 +98,7 @@ def test_gradient(actx_factory, form, dim, order, vectorize, nested,
         def get_flux(u_tpair):
             dd = u_tpair.dd
             dd_allfaces = dd.with_dtag("all_faces")
-            normal = thaw(op.normal(dcoll, dd), actx)
+            normal = thaw(dcoll.normal(dd), actx)
             u_avg = u_tpair.avg
             if vectorize:
                 if nested:
@@ -212,7 +212,7 @@ def test_divergence(actx_factory, form, dim, order, vectorize, nested,
             result = result + deriv
             return result
 
-        x = thaw(op.nodes(dcoll), actx)
+        x = thaw(dcoll.nodes(), actx)
 
         if vectorize:
             u = make_obj_array([(i+1)*f(x) for i in range(dim)])
@@ -224,7 +224,7 @@ def test_divergence(actx_factory, form, dim, order, vectorize, nested,
         def get_flux(u_tpair):
             dd = u_tpair.dd
             dd_allfaces = dd.with_dtag("all_faces")
-            normal = thaw(op.normal(dcoll, dd), actx)
+            normal = thaw(dcoll.normal(dd), actx)
             flux = u_tpair.avg @ normal
             return op.project(dcoll, dd, dd_allfaces, flux)
 


### PR DESCRIPTION
Requires/Targets #108 because of the `dt_utils` module. This PR cuts down the content in `grudge.op` and modularizes the projection/interpolation and the reductions.

This also removes `op.nodes`/`op.normal`. The reason for this is due to the discussion here: https://github.com/illinois-ceesd/mirgecom/pull/360#discussion_r638097941. Overall, I pretty much agree that it makes much more sense to keep `nodes`/`normal` with the discretization collection. Furthermore, we should not need to deprecate since Mirgecom (our only direct dependency) has yet to adopt the post-eager interface. So we have a unique opportunity here to make some decisions that won't cause widespread breakage.

It also semi-revives `interp` in anticipate of addressing issue https://github.com/inducer/grudge/issues/38 in a future PR (not this one). Also `interp` and `project` was _intentially_ split into two modules. The reason I did this is that we may want to expand the behavior for these functions as more and more features get added. I think it will be easier to maintain them if we keep them self-contained.