### PR TITLE
Refactor DiscretizationCollection constructor

### DIFF
--- a/examples/advection/surface.py
+++ b/examples/advection/surface.py
@@ -158,9 +158,9 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
         discr_tag_to_group_factory[qtag] = \
             QuadratureSimplexGroupFactory(order=4*order)
 
-    from grudge import DiscretizationCollection
+    from grudge import make_discretization_collection
 
-    dcoll = DiscretizationCollection(
+    dcoll = make_discretization_collection(
         actx, mesh,
         discr_tag_to_group_factory=discr_tag_to_group_factory
     )

--- a/examples/advection/var-velocity.py
+++ b/examples/advection/var-velocity.py
@@ -146,9 +146,9 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
     else:
         discr_tag_to_group_factory = {}
 
-    from grudge import DiscretizationCollection
+    from grudge import make_discretization_collection
 
-    dcoll = DiscretizationCollection(
+    dcoll = make_discretization_collection(
         actx, mesh, order=order,
         discr_tag_to_group_factory=discr_tag_to_group_factory
     )

--- a/examples/advection/weak.py
+++ b/examples/advection/weak.py
@@ -134,9 +134,9 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
             [np.linspace(-d/2, d/2, npoints) for _ in range(dim)],
             order=order)
 
-    from grudge import DiscretizationCollection
+    from grudge import make_discretization_collection
 
-    dcoll = DiscretizationCollection(actx, mesh, order=order)
+    dcoll = make_discretization_collection(actx, mesh, order=order)
 
     # }}}
 

--- a/examples/geometry.py
+++ b/examples/geometry.py
@@ -33,7 +33,7 @@ import pyopencl.tools as cl_tools
 from arraycontext import thaw
 from grudge.array_context import PyOpenCLArrayContext
 
-from grudge import DiscretizationCollection, shortcuts
+from grudge import make_discretization_collection, shortcuts
 
 
 def main(write_output=True):
@@ -49,7 +49,7 @@ def main(write_output=True):
     from meshmode.mesh.generation import generate_warped_rect_mesh
     mesh = generate_warped_rect_mesh(dim=2, order=4, nelements_side=6)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=4)
+    dcoll = make_discretization_collection(actx, mesh, order=4)
 
     nodes = thaw(dcoll.nodes(), actx)
     bdry_nodes = thaw(dcoll.nodes(dd=BTAG_ALL), actx)

--- a/examples/hello-grudge.py
+++ b/examples/hello-grudge.py
@@ -10,7 +10,7 @@
 # BEGINEXAMPLE
 import numpy as np
 import pyopencl as cl
-from grudge.discretization import DiscretizationCollection
+from grudge.discretization import make_discretization_collection
 import grudge.op as op
 from meshmode.mesh.generation import generate_box_mesh
 from meshmode.array_context import PyOpenCLArrayContext
@@ -27,7 +27,7 @@ coords = np.linspace(0, 2*np.pi, nel)
 mesh = generate_box_mesh((coords,),
                          boundary_tag_to_face={"left": ["-x"],
                                                "right": ["+x"]})
-dcoll = DiscretizationCollection(actx, mesh, order=1)
+dcoll = make_discretization_collection(actx, mesh, order=1)
 
 
 def initial_condition(x):

--- a/examples/maxwell/cavities.py
+++ b/examples/maxwell/cavities.py
@@ -34,7 +34,7 @@ from arraycontext import thaw
 from grudge.array_context import PyOpenCLArrayContext
 
 from grudge.shortcuts import set_up_rk4
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 from grudge.models.em import get_rectangular_cavity_mode
 
@@ -59,7 +59,7 @@ def main(ctx_factory, dim=3, order=4, visualize=False):
             b=(1.0,)*dim,
             nelements_per_axis=(4,)*dim)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=order)
+    dcoll = make_discretization_collection(actx, mesh, order=order)
 
     if 0:
         epsilon0 = 8.8541878176e-12  # C**2 / (N m**2)

--- a/examples/old_symbolics/dagrt-fusion.py
+++ b/examples/old_symbolics/dagrt-fusion.py
@@ -77,7 +77,7 @@ from pymbolic.mapper.evaluator import EvaluationMapper \
 from pytools import memoize
 from pytools.obj_array import flat_obj_array
 
-from grudge import sym, bind, DiscretizationCollection
+from grudge import sym, bind, make_discretization_collection
 from leap.rk import LSRK4MethodBuilder
 
 from pyopencl.tools import (  # noqa
@@ -573,7 +573,7 @@ def get_wave_op_with_discr(actx, dims=2, order=4):
 
     logger.debug("%d elements", mesh.nelements)
 
-    discr = DiscretizationCollection(actx, mesh, order=order)
+    discr = make_discretization_collection(actx, mesh, order=order)
 
     from symbolic_wave_op import WeakWaveOperator
     from meshmode.mesh import BTAG_ALL, BTAG_NONE

--- a/examples/wave/var-propagation-speed.py
+++ b/examples/wave/var-propagation-speed.py
@@ -34,7 +34,7 @@ from arraycontext import thaw
 from grudge.array_context import PyOpenCLArrayContext
 
 from grudge.shortcuts import set_up_rk4
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 from pytools.obj_array import flat_obj_array
 
@@ -59,7 +59,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
             b=(0.5,)*dim,
             nelements_per_axis=(20,)*dim)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=order)
+    dcoll = make_discretization_collection(actx, mesh, order=order)
 
     def source_f(actx, dcoll, t=0):
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]

--- a/examples/wave/wave-min-mpi.py
+++ b/examples/wave/wave-min-mpi.py
@@ -34,7 +34,7 @@ from arraycontext import thaw
 from grudge.array_context import PyOpenCLArrayContext
 
 from grudge.shortcuts import set_up_rk4
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 from mpi4py import MPI
 
@@ -79,8 +79,10 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
     else:
         local_mesh = mesh_dist.receive_mesh_part()
 
-    dcoll = DiscretizationCollection(actx, local_mesh, order=order,
-            mpi_communicator=comm)
+    dcoll = make_discretization_collection(
+        actx, local_mesh, order=order,
+        mpi_communicator=comm
+    )
 
     def source_f(actx, dcoll, t=0):
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]

--- a/examples/wave/wave-op-mpi.py
+++ b/examples/wave/wave-op-mpi.py
@@ -38,7 +38,7 @@ from pytools.obj_array import flat_obj_array
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
-from grudge.discretization import DiscretizationCollection
+from grudge.discretization import make_discretization_collection
 from grudge.shortcuts import make_visualizer
 
 import grudge.op as op
@@ -176,8 +176,10 @@ def main(ctx_factory, dim=2, order=3, visualize=False):
     else:
         local_mesh = mesh_dist.receive_mesh_part()
 
-    dcoll = DiscretizationCollection(actx, local_mesh, order=order,
-                    mpi_communicator=comm)
+    dcoll = make_discretization_collection(
+        actx, local_mesh, order=order,
+        mpi_communicator=comm
+    )
 
     fields = flat_obj_array(
             bump(actx, dcoll),

--- a/examples/wave/wave-op-var-velocity.py
+++ b/examples/wave/wave-op-var-velocity.py
@@ -38,7 +38,7 @@ from pytools.obj_array import flat_obj_array
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
-from grudge.discretization import DiscretizationCollection
+from grudge.discretization import make_discretization_collection
 from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD, DOFDesc
 from grudge.shortcuts import make_visualizer
 
@@ -179,7 +179,7 @@ def main(ctx_factory, dim=2, order=3, visualize=False):
     from meshmode.discretization.poly_element import \
             QuadratureSimplexGroupFactory, \
             default_simplex_group_factory
-    dcoll = DiscretizationCollection(
+    dcoll = make_discretization_collection(
         actx, mesh,
         discr_tag_to_group_factory={
             DISCR_TAG_BASE: default_simplex_group_factory(base_dim=dim, order=order),

--- a/grudge/__init__.py
+++ b/grudge/__init__.py
@@ -1,4 +1,7 @@
-__copyright__ = "Copyright (C) 2015 Andreas Kloeckner"
+__copyright__ = """
+Copyright (C) 2015 Andreas Kloeckner
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
 
 __license__ = """
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,8 +26,13 @@ THE SOFTWARE.
 import grudge.symbolic as sym
 from grudge.execution import bind
 
-from grudge.discretization import DiscretizationCollection
+from grudge.discretization import (
+    DiscretizationCollection,
+    make_discretization_collection
+)
 
 __all__ = [
-    "sym", "bind", "DiscretizationCollection"
+    "sym", "bind",
+    "DiscretizationCollection",
+    "make_discretization_collection"
 ]

--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -112,7 +112,8 @@ class DiscretizationCollection:
             discretization.
         :arg dist_boundary_connections: A dictionary whose keys denote the
             partition group index and map to the appropriate face connections
-            for distributed boundaries, if any.
+            for distributed boundaries, if any. See
+            :func:`set_up_distributed_communication` for more information.
         :arg mpi_communicator: An (optional) MPI communicator.
         """
         self._setup_actx = array_context
@@ -736,6 +737,8 @@ def set_up_distributed_communication(
         comm=None) -> Dict[int, DiscretizationConnection]:
     """Constructs a mapping from parallel boundary partition and the relevant
     discretization connections to that boundary. Used for distributed runs.
+    Connected partitions are determined by
+    :func:`meshmode.distributed.get_connected_partitions`.
 
     :arg base_discr: A :class:`meshmode.discretization.Discretization`
         object for the base (:class:`grudge.dof_desc.DISCR_TAG_BASE`)

--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -569,13 +569,16 @@ class DiscretizationCollection:
 # {{{ Discretization construction routines
 
 def make_discretization_collection(
-        array_context: ArrayContext, mesh: Mesh,
+        array_context: ArrayContext,
+        discr_context,
         order=None,
         discr_tag_to_group_factory=None,
         mpi_communicator=None) -> DiscretizationCollection:
-    """Construct a discretization collection given an array context *array_context*,
-    mesh *mesh*, and user-provided discretization parameters.
+    """Construct a discretization collection given an array context *array_context*
+    and user-provided discretization parameters.
 
+    :arg discr_context: A :class:`~meshmode.mesh.Mesh` object to define
+        the discretization collection over.
     :arg discr_tag_to_group_factory: A mapping from discretization tags
         (typically one of: :class:`grudge.dof_desc.DISCR_TAG_BASE`,
         :class:`grudge.dof_desc.DISCR_TAG_MODAL`, or
@@ -588,6 +591,12 @@ def make_discretization_collection(
     :arg mpi_communicator: An (optional) MPI communicator.
     :returns: A :class:`DiscretizationCollection`.
     """
+    if not isinstance(discr_context, Mesh):
+        raise NotImplementedError(
+            "Currently `discr_context` must be a meshmode Mesh object"
+        )
+    mesh = discr_context
+
     from meshmode.discretization.poly_element import \
         default_simplex_group_factory
 

--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -685,15 +685,6 @@ def set_up_distributed_communication(
     return boundary_connections
 
 
-class DGDiscretizationWithBoundaries(DiscretizationCollection):
-    def __init__(self, *args, **kwargs):
-        warn("DGDiscretizationWithBoundaries is deprecated and will go away "
-                "in 2022. Use DiscretizationCollection instead.",
-                DeprecationWarning, stacklevel=2)
-
-        super().__init__(*args, **kwargs)
-
-
 def _generate_modal_group_factory(nodal_group_factory):
     from meshmode.discretization.poly_element import (
         ModalSimplexGroupFactory,

--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -57,6 +57,8 @@ from meshmode.mesh import Mesh, BTAG_PARTITION
 from warnings import warn
 
 
+# {{{ Discretization collection
+
 class DiscretizationCollection:
     """A collection of discretizations, defined on the same underlying
     :class:`~meshmode.mesh.Mesh`, corresponding to various mesh entities
@@ -561,6 +563,10 @@ class DiscretizationCollection:
 
     # }}}
 
+# }}}
+
+
+# {{{ Discretization construction routines
 
 def make_discretization_collection(
         array_context: ArrayContext, mesh: Mesh,
@@ -718,5 +724,8 @@ def _generate_modal_group_factory(nodal_group_factory):
         raise ValueError(
             f"Unknown mesh element group: {mesh_group_cls}"
         )
+
+# }}}
+
 
 # vim: foldmethod=marker

--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -573,7 +573,8 @@ def make_discretization_collection(
         order=None,
         discr_tag_to_group_factory=None,
         mpi_communicator=None) -> DiscretizationCollection:
-    """Construct a discretization collection.
+    """Construct a discretization collection given an array context *array_context*,
+    mesh *mesh*, and user-provided discretization parameters.
 
     :arg discr_tag_to_group_factory: A mapping from discretization tags
         (typically one of: :class:`grudge.dof_desc.DISCR_TAG_BASE`,
@@ -584,6 +585,7 @@ def make_discretization_collection(
         to be carried out, or *None* to indicate that operations with this
         discretization tag should be carried out with the standard volume
         discretization.
+    :arg mpi_communicator: An (optional) MPI communicator.
     :returns: A :class:`DiscretizationCollection`.
     """
     from meshmode.discretization.poly_element import \
@@ -654,7 +656,9 @@ def set_up_distributed_communication(
         array_context: ArrayContext, mesh: Mesh,
         volume_discr,
         discr_tag_to_group_factory, comm=None) -> dict:
-    """
+    """Constructs a mapping from parallel boundary partition and the relevant
+    discretization connections to that boundary. Used for distributed runs.
+
     :arg volume_discr: A :class:`meshmode.discretization.Discretization`
         object for the base (:class:`grudge.dof_desc.DISCR_TAG_BASE`)
         volume discretization.
@@ -707,6 +711,9 @@ def set_up_distributed_communication(
 
 
 def _generate_modal_group_factory(nodal_group_factory):
+    """Returns the relevant modal element group factory for a
+    given nodal group factory *nodal_group_factory*.
+    """
     from meshmode.discretization.poly_element import (
         ModalSimplexGroupFactory,
         ModalTensorProductGroupFactory

--- a/grudge/discretization.py
+++ b/grudge/discretization.py
@@ -35,7 +35,6 @@ from pytools import memoize_method
 
 from grudge.dof_desc import (
     DD_VOLUME,
-    DD_VOLUME_MODAL,
     DISCR_TAG_BASE,
     DISCR_TAG_MODAL,
     DTAG_BOUNDARY,
@@ -709,11 +708,12 @@ def make_discretization_collection(
             discr_tag_to_group_factory[DISCR_TAG_BASE] = \
                 default_simplex_group_factory(base_dim=mesh.dim, order=order)
 
-    # Modal discr should always comes from the base discretization
-    discr_tag_to_group_factory[DISCR_TAG_MODAL] = \
-        _generate_modal_group_factory(
-            discr_tag_to_group_factory[DISCR_TAG_BASE]
-        )
+    # Supply modal group factory if not provided
+    if DISCR_TAG_MODAL not in discr_tag_to_group_factory:
+        discr_tag_to_group_factory[DISCR_TAG_MODAL] = \
+            _generate_modal_group_factory(
+                discr_tag_to_group_factory[DISCR_TAG_BASE]
+            )
 
     # Define the base and modal discretization
     from meshmode.discretization import Discretization
@@ -723,13 +723,7 @@ def make_discretization_collection(
         discr_tag_to_group_factory[DISCR_TAG_BASE]
     )
 
-    modal_vol_discr = Discretization(
-        array_context, mesh,
-        discr_tag_to_group_factory[DISCR_TAG_MODAL]
-    )
-
-    discr_from_dd = {DD_VOLUME: base_discr,
-                     DD_VOLUME_MODAL: modal_vol_discr}
+    discr_from_dd = {DD_VOLUME: base_discr}
 
     # Define boundary connections
     dist_boundary_connections = set_up_distributed_communication(

--- a/grudge/eager.py
+++ b/grudge/eager.py
@@ -101,13 +101,22 @@ class EagerDGDiscretization(DiscretizationCollection):
                 discr_tag_to_group_factory[DISCR_TAG_BASE]
             )
 
-        # Define the base discretization
+        # Define the base and modal discretization
+        from grudge.dof_desc import DD_VOLUME, DD_VOLUME_MODAL
         from meshmode.discretization import Discretization
 
         volume_discr = Discretization(
             array_context, mesh,
             discr_tag_to_group_factory[DISCR_TAG_BASE]
         )
+
+        modal_vol_discr = Discretization(
+            array_context, mesh,
+            discr_tag_to_group_factory[DISCR_TAG_MODAL]
+        )
+
+        discr_from_dd = {DD_VOLUME: volume_discr,
+                         DD_VOLUME_MODAL: modal_vol_discr}
 
         # Define boundary connections
         from grudge.discretization import set_up_distributed_communication
@@ -122,7 +131,7 @@ class EagerDGDiscretization(DiscretizationCollection):
             array_context=array_context,
             mesh=mesh,
             discr_tag_to_group_factory=discr_tag_to_group_factory,
-            volume_discr=volume_discr,
+            discr_from_dd=discr_from_dd,
             dist_boundary_connections=dist_boundary_connections,
             mpi_communicator=mpi_communicator
         )

--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -268,7 +268,7 @@ def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
 @memoize_on_first_arg
 def connected_ranks(dcoll: DiscretizationCollection):
     from meshmode.distributed import get_connected_partitions
-    return get_connected_partitions(dcoll._volume_discr.mesh)
+    return get_connected_partitions(dcoll.mesh)
 
 
 class _RankBoundaryCommunication:

--- a/test/test_dt_utils.py
+++ b/test/test_dt_utils.py
@@ -31,7 +31,7 @@ from arraycontext import pytest_generate_tests_for_array_contexts
 pytest_generate_tests = pytest_generate_tests_for_array_contexts(
         [PytestPyOpenCLArrayContextFactory])
 
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 import grudge.op as op
 
@@ -68,7 +68,7 @@ def test_geometric_factors_regular_refinement(actx_factory, name):
     min_factors = []
     for resolution in builder.resolutions:
         mesh = builder.get_mesh(resolution, builder.mesh_order)
-        dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+        dcoll = make_discretization_collection(actx, mesh, order=builder.order)
         min_factors.append(
             op.nodal_min(dcoll, "vol", thaw(dt_geometric_factors(dcoll), actx))
         )
@@ -106,7 +106,7 @@ def test_non_geometric_factors(actx_factory, name):
     degrees = list(range(1, 8))
     for degree in degrees:
         mesh = builder.get_mesh(1, degree)
-        dcoll = DiscretizationCollection(actx, mesh, order=degree)
+        dcoll = make_discretization_collection(actx, mesh, order=degree)
         factors.append(min(dt_non_geometric_factors(dcoll)))
 
     # Crude estimate, factors should behave like 1/N**2

--- a/test/test_grudge.py
+++ b/test/test_grudge.py
@@ -38,7 +38,7 @@ import meshmode.mesh.generation as mgen
 
 from pytools.obj_array import flat_obj_array, make_obj_array
 
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 import grudge.dof_desc as dof_desc
 import grudge.op as op
@@ -75,7 +75,7 @@ def test_inverse_metric(actx_factory, dim):
     from meshmode.mesh.processing import map_mesh
     mesh = map_mesh(mesh, m)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=4)
+    dcoll = make_discretization_collection(actx, mesh, order=4)
 
     from grudge.geometry import \
         forward_metric_derivative_mat, inverse_metric_derivative_mat
@@ -124,7 +124,7 @@ def test_mass_mat_trig(actx_factory, ambient_dim, discr_tag):
     mesh = mgen.generate_regular_rect_mesh(
             a=(a,)*ambient_dim, b=(b,)*ambient_dim,
             nelements_per_axis=(nel_1d,)*ambient_dim, order=1)
-    dcoll = DiscretizationCollection(
+    dcoll = make_discretization_collection(
         actx, mesh, order=order,
         discr_tag_to_group_factory=discr_tag_to_group_factory
     )
@@ -231,7 +231,7 @@ def test_mass_surface_area(actx_factory, name):
 
     for resolution in builder.resolutions:
         mesh = builder.get_mesh(resolution, builder.mesh_order)
-        dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+        dcoll = make_discretization_collection(actx, mesh, order=builder.order)
         volume_discr = dcoll.discr_from_dd(dof_desc.DD_VOLUME)
 
         logger.info("ndofs:     %d", volume_discr.ndofs)
@@ -300,7 +300,7 @@ def test_mass_operator_inverse(actx_factory, name):
 
     for resolution in builder.resolutions:
         mesh = builder.get_mesh(resolution, builder.mesh_order)
-        dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+        dcoll = make_discretization_collection(actx, mesh, order=builder.order)
         volume_discr = dcoll.discr_from_dd(dof_desc.DD_VOLUME)
 
         logger.info("ndofs:     %d", volume_discr.ndofs)
@@ -360,7 +360,7 @@ def test_face_normal_surface(actx_factory, mesh_name):
         raise ValueError("unknown mesh name: %s" % mesh_name)
 
     mesh = builder.get_mesh(builder.resolutions[0], builder.mesh_order)
-    dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+    dcoll = make_discretization_collection(actx, mesh, order=builder.order)
 
     volume_discr = dcoll.discr_from_dd(dof_desc.DD_VOLUME)
     logger.info("ndofs:    %d", volume_discr.ndofs)
@@ -447,7 +447,7 @@ def test_tri_diff_mat(actx_factory, dim, order=4):
         mesh = mgen.generate_regular_rect_mesh(a=(-0.5,)*dim, b=(0.5,)*dim,
                 nelements_per_axis=(n,)*dim, order=4)
 
-        dcoll = DiscretizationCollection(actx, mesh, order=4)
+        dcoll = make_discretization_collection(actx, mesh, order=4)
         volume_discr = dcoll.discr_from_dd(dof_desc.DD_VOLUME)
         x = thaw(volume_discr.nodes(), actx)
 
@@ -489,7 +489,7 @@ def test_2d_gauss_theorem(actx_factory):
 
     actx = actx_factory()
 
-    dcoll = DiscretizationCollection(actx, mesh, order=2)
+    dcoll = make_discretization_collection(actx, mesh, order=2)
     volm_disc = dcoll.discr_from_dd(dof_desc.DD_VOLUME)
     x_volm = thaw(volm_disc.nodes(), actx)
 
@@ -588,7 +588,7 @@ def test_surface_divergence_theorem(actx_factory, mesh_name, visualize=False):
                 QuadratureSimplexGroupFactory
 
         qtag = dof_desc.DISCR_TAG_QUAD
-        dcoll = DiscretizationCollection(
+        dcoll = make_discretization_collection(
             actx, mesh, order=builder.order,
             discr_tag_to_group_factory={
                 qtag: QuadratureSimplexGroupFactory(2 * builder.order)
@@ -749,7 +749,7 @@ def test_convergence_advec(actx_factory, mesh_name, mesh_pars, op_type, flux_typ
         )
         from meshmode.mesh import BTAG_ALL
 
-        dcoll = DiscretizationCollection(actx, mesh, order=order)
+        dcoll = make_discretization_collection(actx, mesh, order=order)
         op_class = {"strong": StrongAdvectionOperator,
                     "weak": WeakAdvectionOperator}[op_type]
         adv_operator = op_class(dcoll, v,
@@ -841,7 +841,7 @@ def test_convergence_maxwell(actx_factory,  order):
                 b=(1.0,)*dims,
                 nelements_per_axis=(n,)*dims)
 
-        dcoll = DiscretizationCollection(actx, mesh, order=order)
+        dcoll = make_discretization_collection(actx, mesh, order=order)
 
         epsilon = 1
         mu = 1
@@ -943,7 +943,7 @@ def test_improvement_quadrature(actx_factory, order):
             else:
                 discr_tag_to_group_factory = {}
 
-            dcoll = DiscretizationCollection(
+            dcoll = make_discretization_collection(
                 actx, mesh, order=order,
                 discr_tag_to_group_factory=discr_tag_to_group_factory
             )
@@ -995,7 +995,7 @@ def test_bessel(actx_factory):
             b=(1.0,)*dims,
             nelements_per_axis=(8,)*dims)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=3)
+    dcoll = make_discretization_collection(actx, mesh, order=3)
 
     nodes = thaw(dcoll.nodes(), actx)
     r = actx.np.sqrt(nodes[0]**2 + nodes[1]**2)
@@ -1027,7 +1027,7 @@ def test_norm_complex(actx_factory, p):
     mesh = mgen.generate_regular_rect_mesh(
             a=(0,)*dim, b=(1,)*dim,
             nelements_per_axis=(8,)*dim, order=1)
-    dcoll = DiscretizationCollection(actx, mesh, order=4)
+    dcoll = make_discretization_collection(actx, mesh, order=4)
 
     nodes = thaw(dcoll.nodes(), actx)
     f = nodes[0] + 1j * nodes[0]
@@ -1051,7 +1051,7 @@ def test_norm_obj_array(actx_factory, p):
     mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*dim, b=(0.5,)*dim,
             nelements_per_axis=(8,)*dim, order=1)
-    dcoll = DiscretizationCollection(actx, mesh, order=4)
+    dcoll = make_discretization_collection(actx, mesh, order=4)
 
     w = make_obj_array([1.0, 2.0, 3.0])[:dim]
 
@@ -1087,7 +1087,7 @@ def test_empty_boundary(actx_factory):
     mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*dim, b=(0.5,)*dim,
             nelements_per_axis=(8,)*dim, order=4)
-    dcoll = DiscretizationCollection(actx, mesh, order=4)
+    dcoll = make_discretization_collection(actx, mesh, order=4)
     normal = dcoll.normal(BTAG_NONE)
     from meshmode.dof_array import DOFArray
     for component in normal:

--- a/test/test_grudge_sym_old.py
+++ b/test/test_grudge_sym_old.py
@@ -27,7 +27,7 @@ import meshmode.mesh.generation as mgen
 
 from pytools.obj_array import flat_obj_array, make_obj_array
 
-from grudge import sym, bind, DiscretizationCollection
+from grudge import sym, bind, make_discretization_collection
 
 import grudge.dof_desc as dof_desc
 
@@ -67,7 +67,7 @@ def test_inverse_metric(actx_factory, dim):
     from meshmode.mesh.processing import map_mesh
     mesh = map_mesh(mesh, m)
 
-    discr = DiscretizationCollection(actx, mesh, order=4)
+    discr = make_discretization_collection(actx, mesh, order=4)
 
     sym_op = (
             sym.forward_metric_derivative_mat(mesh.dim)
@@ -120,7 +120,7 @@ def test_mass_mat_trig(actx_factory, ambient_dim, discr_tag):
     mesh = mgen.generate_regular_rect_mesh(
             a=(a,)*ambient_dim, b=(b,)*ambient_dim,
             nelements_per_axis=(nel_1d,)*ambient_dim, order=1)
-    discr = DiscretizationCollection(
+    discr = make_discretization_collection(
         actx, mesh, order=order,
         discr_tag_to_group_factory=discr_tag_to_group_factory
     )
@@ -226,7 +226,7 @@ def test_mass_surface_area(actx_factory, name):
 
     for resolution in builder.resolutions:
         mesh = builder.get_mesh(resolution, builder.mesh_order)
-        discr = DiscretizationCollection(actx, mesh, order=builder.order)
+        discr = make_discretization_collection(actx, mesh, order=builder.order)
         volume_discr = discr.discr_from_dd(dof_desc.DD_VOLUME)
 
         logger.info("ndofs:     %d", volume_discr.ndofs)
@@ -284,7 +284,7 @@ def test_surface_mass_operator_inverse(actx_factory, name):
 
     for resolution in builder.resolutions:
         mesh = builder.get_mesh(resolution, builder.mesh_order)
-        discr = DiscretizationCollection(actx, mesh, order=builder.order)
+        discr = make_discretization_collection(actx, mesh, order=builder.order)
         volume_discr = discr.discr_from_dd(dof_desc.DD_VOLUME)
 
         logger.info("ndofs:     %d", volume_discr.ndofs)
@@ -340,7 +340,7 @@ def test_face_normal_surface(actx_factory, mesh_name):
         raise ValueError("unknown mesh name: %s" % mesh_name)
 
     mesh = builder.get_mesh(builder.resolutions[0], builder.mesh_order)
-    discr = DiscretizationCollection(actx, mesh, order=builder.order)
+    discr = make_discretization_collection(actx, mesh, order=builder.order)
 
     volume_discr = discr.discr_from_dd(dof_desc.DD_VOLUME)
     logger.info("ndofs:    %d", volume_discr.ndofs)
@@ -426,7 +426,7 @@ def test_tri_diff_mat(actx_factory, dim, order=4):
         mesh = mgen.generate_regular_rect_mesh(a=(-0.5,)*dim, b=(0.5,)*dim,
                 nelements_per_axis=(n,)*dim, order=4)
 
-        discr = DiscretizationCollection(actx, mesh, order=4)
+        discr = make_discretization_collection(actx, mesh, order=4)
         nabla = sym.nabla(dim)
 
         for axis in range(dim):
@@ -473,7 +473,7 @@ def test_2d_gauss_theorem(actx_factory):
 
     actx = actx_factory()
 
-    discr = DiscretizationCollection(actx, mesh, order=2)
+    discr = make_discretization_collection(actx, mesh, order=2)
 
     def f(x):
         return flat_obj_array(
@@ -571,7 +571,7 @@ def test_surface_divergence_theorem(actx_factory, mesh_name, visualize=False):
 
         from meshmode.discretization.poly_element import \
                 QuadratureSimplexGroupFactory
-        discr = DiscretizationCollection(
+        discr = make_discretization_collection(
             actx, mesh, order=builder.order,
             discr_tag_to_group_factory={
                     "product": QuadratureSimplexGroupFactory(2 * builder.order)
@@ -692,7 +692,7 @@ def test_bessel(actx_factory):
             b=(1.0,)*dims,
             nelements_per_axis=(8,)*dims)
 
-    discr = DiscretizationCollection(actx, mesh, order=3)
+    discr = make_discretization_collection(actx, mesh, order=3)
 
     nodes = sym.nodes(dims)
     r = sym.cse(sym.sqrt(nodes[0]**2 + nodes[1]**2))
@@ -723,7 +723,7 @@ def test_external_call(actx_factory):
 
     mesh = mgen.generate_regular_rect_mesh(
             a=(0,) * dims, b=(1,) * dims, nelements_per_axis=(4,) * dims)
-    discr = DiscretizationCollection(actx, mesh, order=1)
+    discr = make_discretization_collection(actx, mesh, order=1)
 
     ones = sym.Ones(dof_desc.DD_VOLUME)
     op = (
@@ -755,7 +755,7 @@ def test_function_symbol_array(actx_factory, array_type):
     mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*dim, b=(0.5,)*dim,
             nelements_per_axis=(8,)*dim, order=4)
-    discr = DiscretizationCollection(actx, mesh, order=4)
+    discr = make_discretization_collection(actx, mesh, order=4)
     volume_discr = discr.discr_from_dd(dof_desc.DD_VOLUME)
 
     if array_type == "scalar":
@@ -783,7 +783,7 @@ def test_norm_obj_array(actx_factory, p):
     mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*dim, b=(0.5,)*dim,
             nelements_per_axis=(8,)*dim, order=1)
-    discr = DiscretizationCollection(actx, mesh, order=4)
+    discr = make_discretization_collection(actx, mesh, order=4)
 
     w = make_obj_array([1.0, 2.0, 3.0])[:dim]
 
@@ -821,7 +821,7 @@ def test_map_if(actx_factory):
     mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*dim, b=(0.5,)*dim,
             nelements_per_axis=(8,)*dim, order=4)
-    discr = DiscretizationCollection(actx, mesh, order=4)
+    discr = make_discretization_collection(actx, mesh, order=4)
 
     sym_if = sym.If(sym.Comparison(2.0, "<", 1.0e-14), 1.0, 2.0)
     bind(discr, sym_if)(actx)
@@ -838,7 +838,7 @@ def test_empty_boundary(actx_factory):
     mesh = mgen.generate_regular_rect_mesh(
             a=(-0.5,)*dim, b=(0.5,)*dim,
             nelements_per_axis=(8,)*dim, order=4)
-    discr = DiscretizationCollection(actx, mesh, order=4)
+    discr = make_discretization_collection(actx, mesh, order=4)
     normal = bind(discr,
             sym.normal(BTAG_NONE, dim, dim=dim - 1))(actx)
     from meshmode.dof_array import DOFArray
@@ -861,7 +861,7 @@ def test_operator_compiler_overwrite(actx_factory):
     mesh = generate_regular_rect_mesh(
             a=(-0.5,)*ambient_dim, b=(0.5,)*ambient_dim,
             n=(8,)*ambient_dim, order=1)
-    discr = DiscretizationCollection(actx, mesh, order=target_order)
+    discr = make_discretization_collection(actx, mesh, order=target_order)
 
     # {{{ test
 
@@ -893,7 +893,7 @@ def test_incorrect_assignment_aggregation(actx_factory, ambient_dim):
     mesh = generate_regular_rect_mesh(
             a=(-0.5,)*ambient_dim, b=(0.5,)*ambient_dim,
             n=(8,)*ambient_dim, order=1)
-    discr = DiscretizationCollection(actx, mesh, order=target_order)
+    discr = make_discretization_collection(actx, mesh, order=target_order)
 
     # {{{ test with a relative norm
 

--- a/test/test_modal_connections.py
+++ b/test/test_modal_connections.py
@@ -40,7 +40,7 @@ from meshmode.discretization.poly_element import (
 from meshmode.dof_array import flat_norm
 import meshmode.mesh.generation as mgen
 
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 import grudge.dof_desc as dof_desc
 
 import pytest
@@ -66,7 +66,7 @@ def test_inverse_modal_connections(actx_factory, nodal_group_factory):
         group_cls=nodal_group_factory.mesh_group_class
     )
 
-    dcoll = DiscretizationCollection(
+    dcoll = make_discretization_collection(
         actx, mesh,
         discr_tag_to_group_factory={
             dof_desc.DISCR_TAG_BASE: nodal_group_factory(order)
@@ -106,7 +106,7 @@ def test_inverse_modal_connections_quadgrid(actx_factory):
         group_cls=QuadratureSimplexGroupFactory.mesh_group_class
     )
 
-    dcoll = DiscretizationCollection(
+    dcoll = make_discretization_collection(
         actx, mesh,
         discr_tag_to_group_factory={
             dof_desc.DISCR_TAG_BASE:

--- a/test/test_mpi_communication.py
+++ b/test/test_mpi_communication.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig()
 logger.setLevel(logging.INFO)
 
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 from grudge.shortcuts import set_up_rk4
 
 from meshmode.dof_array import flat_norm
@@ -73,8 +73,10 @@ def simple_mpi_communication_entrypoint():
     else:
         local_mesh = mesh_dist.receive_mesh_part()
 
-    dcoll = DiscretizationCollection(actx, local_mesh, order=5,
-            mpi_communicator=comm)
+    dcoll = make_discretization_collection(
+        actx, local_mesh, order=5,
+        mpi_communicator=comm
+    )
 
     x = thaw(dcoll.nodes(), actx)
     myfunc = actx.np.sin(np.dot(x, [2, 3]))
@@ -139,8 +141,10 @@ def mpi_communication_entrypoint():
     else:
         local_mesh = mesh_dist.receive_mesh_part()
 
-    dcoll = DiscretizationCollection(actx, local_mesh, order=order,
-                                     mpi_communicator=comm)
+    dcoll = make_discretization_collection(
+        actx, local_mesh, order=order,
+        mpi_communicator=comm
+    )
 
     def source_f(actx, dcoll, t=0):
         source_center = np.array([0.1, 0.22, 0.33])[:dcoll.dim]

--- a/test/test_op.py
+++ b/test/test_op.py
@@ -27,7 +27,7 @@ import meshmode.mesh.generation as mgen
 
 from pytools.obj_array import make_obj_array
 
-from grudge import op, DiscretizationCollection
+from grudge import op, make_discretization_collection
 from grudge.dof_desc import DOFDesc
 
 import pytest
@@ -66,7 +66,7 @@ def test_gradient(actx_factory, form, dim, order, vectorize, nested,
                 a=(-1,)*dim, b=(1,)*dim,
                 nelements_per_axis=(n,)*dim)
 
-        dcoll = DiscretizationCollection(actx, mesh, order=order)
+        dcoll = make_discretization_collection(actx, mesh, order=order)
 
         def f(x):
             result = dcoll.zeros(actx) + 1
@@ -186,7 +186,7 @@ def test_divergence(actx_factory, form, dim, order, vectorize, nested,
                 a=(-1,)*dim, b=(1,)*dim,
                 nelements_per_axis=(n,)*dim)
 
-        dcoll = DiscretizationCollection(actx, mesh, order=order)
+        dcoll = make_discretization_collection(actx, mesh, order=order)
 
         def f(x):
             result = make_obj_array([dcoll.zeros(actx) + (i+1) for i in range(dim)])

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -31,7 +31,7 @@ from arraycontext import pytest_generate_tests_for_array_contexts
 pytest_generate_tests = pytest_generate_tests_for_array_contexts(
         [PytestPyOpenCLArrayContextFactory])
 
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 import grudge.op as op
 
@@ -54,7 +54,7 @@ def test_nodal_reductions(actx_factory):
     builder = BoxMeshBuilder(ambient_dim=1)
 
     mesh = builder.get_mesh(4, builder.mesh_order)
-    dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+    dcoll = make_discretization_collection(actx, mesh, order=builder.order)
     x = thaw(dcoll.nodes(), actx)
 
     def f(x):
@@ -108,7 +108,7 @@ def test_elementwise_reductions(actx_factory):
 
     nelements = 4
     mesh = builder.get_mesh(nelements, builder.mesh_order)
-    dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+    dcoll = make_discretization_collection(actx, mesh, order=builder.order)
     x = thaw(dcoll.nodes(), actx)
 
     def f(x):
@@ -122,7 +122,7 @@ def test_elementwise_reductions(actx_factory):
         min_res = np.empty(grp_f.shape)
         max_res = np.empty(grp_f.shape)
         sum_res = np.empty(grp_f.shape)
-        for eidx in range(dcoll._volume_discr.groups[gidx].nelements):
+        for eidx in range(dcoll.discr_from_dd("vol").groups[gidx].nelements):
             element_data = actx.to_numpy(grp_f[eidx])
             min_res[eidx, :] = np.min(element_data)
             max_res[eidx, :] = np.max(element_data)

--- a/test/test_trace_pair.py
+++ b/test/test_trace_pair.py
@@ -26,7 +26,7 @@ from grudge.trace_pair import TracePair
 import meshmode.mesh.generation as mgen
 from meshmode.dof_array import DOFArray
 
-from grudge import DiscretizationCollection
+from grudge import make_discretization_collection
 
 from grudge.array_context import PytestPyOpenCLArrayContextFactory
 from arraycontext import pytest_generate_tests_for_array_contexts
@@ -49,7 +49,7 @@ def test_trace_pair(actx_factory):
         a=(-1,)*dim, b=(1,)*dim,
         nelements_per_axis=(n,)*dim)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=order)
+    dcoll = make_discretization_collection(actx, mesh, order=order)
 
     def rand():
         return DOFArray(


### PR DESCRIPTION
This PR removes all the work that the current constructor for `DiscretizationCollection` is doing for setup. The proposed interface for creating these discretization collections is provided by the function `make_discretization_collection`.