### PR TITLE
Elementwise min/max and nodal reductions

### DIFF
--- a/grudge/op.py
+++ b/grudge/op.py
@@ -80,6 +80,8 @@ from grudge.reductions import (  # noqa: F401
     nodal_max_loc,
     integral,
     elementwise_sum,
+    elementwise_max,
+    elementwise_min,
     elementwise_integral,
 )
 

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -95,19 +95,6 @@ from grudge.trace_pair import (  # noqa: F401
 )
 
 
-# {{{ Kernel tags
-
-class HasElementwiseMatvecTag(FirstAxisIsElementsTag):
-    """A tag that is applicable to kernel programs indicating that
-    an element-wise matrix product is being performed. This indicates
-    that the first index corresponds to element indices and suggests that
-    the implementation should set element indices as the outermost
-    loop extent.
-    """
-
-# }}}
-
-
 # {{{ Derivative operators
 
 def reference_derivative_matrices(actx: ArrayContext, element_group):
@@ -144,7 +131,7 @@ def _compute_local_gradient(dcoll: DiscretizationCollection, vec, xyz_axis):
                         reference_derivative_matrices(actx, grp),
                         vec_i,
                         arg_names=("inv_jac_t", "ref_diff_mat", "vec"),
-                        tagged=(HasElementwiseMatvecTag(),))
+                        tagged=(FirstAxisIsElementsTag(),))
 
             for grp, vec_i, inv_jac_t_i in zip(discr.groups, vec, inverse_jac_t)
         )
@@ -316,7 +303,7 @@ def _apply_stiffness_transpose_operator(
                         vec_i,
                         inv_jac_t_i,
                         arg_names=("ref_stiffT_mat", "jac", "vec", "inv_jac_t"),
-                        tagged=(HasElementwiseMatvecTag(),))
+                        tagged=(FirstAxisIsElementsTag(),))
 
             for out_grp, in_grp, vec_i, ae_i, inv_jac_t_i in zip(out_discr.groups,
                                                                  in_discr.groups,
@@ -520,7 +507,7 @@ def _apply_mass_operator(
                         ae_i,
                         vec_i,
                         arg_names=("mass_mat", "jac", "vec"),
-                        tagged=(HasElementwiseMatvecTag(),))
+                        tagged=(FirstAxisIsElementsTag(),))
 
             for in_grp, out_grp, ae_i, vec_i in zip(
                     in_discr.groups, out_discr.groups, area_elements, vec)
@@ -624,7 +611,7 @@ def _apply_inverse_mass_operator(
                         jac_inv,
                         ref_mass_inverse,
                         vec_i,
-                        tagged=(HasElementwiseMatvecTag(),))
+                        tagged=(FirstAxisIsElementsTag(),))
         )
 
     return DOFArray(actx, data=tuple(group_data))

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -137,10 +137,6 @@ def nodal_sum(dcoll: DiscretizationCollection, dd, vec) -> float:
     :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
     :returns: a scalar denoting the nodal sum.
     """
-    if isinstance(vec, np.ndarray):
-        return sum(nodal_sum(dcoll, dd, vec[idx])
-                   for idx in np.ndindex(vec.shape))
-
     comm = dcoll.mpi_communicator
     if comm is None:
         return nodal_sum_loc(dcoll, dd, vec)
@@ -159,6 +155,10 @@ def nodal_sum_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
     :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
     :returns: a scalar denoting the rank-local nodal sum.
     """
+    if isinstance(vec, np.ndarray):
+        return sum(nodal_sum_loc(dcoll, dd, vec[idx])
+                   for idx in np.ndindex(vec.shape))
+
     actx = vec.array_context
     return sum([actx.np.sum(grp_ary) for grp_ary in vec])
 
@@ -171,10 +171,6 @@ def nodal_min(dcoll: DiscretizationCollection, dd, vec) -> float:
     :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
     :returns: a scalar denoting the nodal minimum.
     """
-    if isinstance(vec, np.ndarray):
-        return min(nodal_min(dcoll, dd, vec[idx])
-                   for idx in np.ndindex(vec.shape))
-
     comm = dcoll.mpi_communicator
     if comm is None:
         return nodal_min_loc(dcoll, dd, vec)
@@ -194,6 +190,10 @@ def nodal_min_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
     :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
     :returns: a scalar denoting the rank-local nodal minimum.
     """
+    if isinstance(vec, np.ndarray):
+        return min(nodal_min_loc(dcoll, dd, vec[idx])
+                   for idx in np.ndindex(vec.shape))
+
     actx = vec.array_context
     return reduce(lambda acc, grp_ary: actx.np.minimum(acc, actx.np.min(grp_ary)),
                   vec, np.inf)
@@ -207,10 +207,6 @@ def nodal_max(dcoll: DiscretizationCollection, dd, vec) -> float:
     :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
     :returns: a scalar denoting the nodal maximum.
     """
-    if isinstance(vec, np.ndarray):
-        return max(nodal_max(dcoll, dd, vec[idx])
-                   for idx in np.ndindex(vec.shape))
-
     comm = dcoll.mpi_communicator
     if comm is None:
         return nodal_max_loc(dcoll, dd, vec)
@@ -230,6 +226,10 @@ def nodal_max_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
     :arg vec: a :class:`~meshmode.dof_array.DOFArray`.
     :returns: a scalar denoting the rank-local nodal maximum.
     """
+    if isinstance(vec, np.ndarray):
+        return max(nodal_max_loc(dcoll, dd, vec[idx])
+                   for idx in np.ndindex(vec.shape))
+
     actx = vec.array_context
     return reduce(lambda acc, grp_ary: actx.np.maximum(acc, actx.np.max(grp_ary)),
                   vec, -np.inf)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1,0 +1,145 @@
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+
+from arraycontext import (  # noqa
+    thaw,
+    pytest_generate_tests_for_pyopencl_array_context
+    as pytest_generate_tests
+)
+
+from grudge import DiscretizationCollection
+
+import grudge.op as op
+
+from meshmode.dof_array import flatten
+
+from pytools.obj_array import make_obj_array
+
+import pytest
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_nodal_reductions(actx_factory):
+    actx = actx_factory()
+
+    from mesh_data import BoxMeshBuilder
+    builder = BoxMeshBuilder(ambient_dim=1)
+
+    mesh = builder.get_mesh(4, builder.mesh_order)
+    dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+    x = thaw(dcoll.nodes(), actx)
+
+    def f(x):
+        return -actx.np.sin(10*x[0])
+
+    def g(x):
+        return actx.np.cos(2*x[0])
+
+    def h(x):
+        return -actx.np.tan(5*x[0])
+
+    fields = make_obj_array([f(x), g(x), h(x)])
+
+    f_ref = actx.to_numpy(flatten(fields[0]))
+    g_ref = actx.to_numpy(flatten(fields[1]))
+    h_ref = actx.to_numpy(flatten(fields[2]))
+    concat_fields = np.concatenate([f_ref, g_ref, h_ref])
+
+    for grudge_op, np_op in [(op.nodal_sum, np.sum),
+                             (op.nodal_max, np.max),
+                             (op.nodal_min, np.min)]:
+        # Componentwise reduction checks
+        assert np.isclose(grudge_op(dcoll, "vol", fields[0]),
+                          np_op(f_ref), rtol=1e-13)
+        assert np.isclose(grudge_op(dcoll, "vol", fields[1]),
+                          np_op(g_ref), rtol=1e-13)
+        assert np.isclose(grudge_op(dcoll, "vol", fields[2]),
+                          np_op(h_ref), rtol=1e-13)
+
+        # Test nodal reductions work on object arrays
+        assert np.isclose(grudge_op(dcoll, "vol", fields),
+                          np_op(concat_fields), rtol=1e-13)
+
+
+def test_elementwise_reductions(actx_factory):
+    actx = actx_factory()
+
+    from mesh_data import BoxMeshBuilder
+    builder = BoxMeshBuilder(ambient_dim=1)
+
+    nelements = 4
+    mesh = builder.get_mesh(nelements, builder.mesh_order)
+    dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+    x = thaw(dcoll.nodes(), actx)
+
+    def f(x):
+        return actx.np.sin(x[0])
+
+    field = f(x)
+    mins = []
+    maxs = []
+    sums = []
+    for gidx, grp_f in enumerate(field):
+        min_res = np.empty(grp_f.shape)
+        max_res = np.empty(grp_f.shape)
+        sum_res = np.empty(grp_f.shape)
+        for eidx in range(dcoll._volume_discr.groups[gidx].nelements):
+            element_data = actx.to_numpy(grp_f[eidx])
+            min_res[eidx, :] = np.min(element_data)
+            max_res[eidx, :] = np.max(element_data)
+            sum_res[eidx, :] = np.sum(element_data)
+        mins.append(actx.from_numpy(min_res))
+        maxs.append(actx.from_numpy(max_res))
+        sums.append(actx.from_numpy(sum_res))
+
+    from meshmode.dof_array import DOFArray, flat_norm
+
+    ref_mins = DOFArray(actx, data=tuple(mins))
+    ref_maxs = DOFArray(actx, data=tuple(maxs))
+    ref_sums = DOFArray(actx, data=tuple(sums))
+
+    elem_mins = op.elementwise_min(dcoll, field)
+    elem_maxs = op.elementwise_max(dcoll, field)
+    elem_sums = op.elementwise_sum(dcoll, field)
+
+    assert flat_norm(elem_mins - ref_mins, ord=np.inf) < 1.e-15
+    assert flat_norm(elem_maxs - ref_maxs, ord=np.inf) < 1.e-15
+    assert flat_norm(elem_sums - ref_sums, ord=np.inf) < 1.e-15
+
+
+# You can test individual routines by typing
+# $ python test_grudge.py 'test_routine()'
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        pytest.main([__file__])


### PR DESCRIPTION
Allows nodal reductions to accept object arrays, and adds a couple new elementwise reductions. This PR also adds targeted unit tests for these reductions.