### PR TITLE
Bump tol test mass_mat_trig (symbolic tests)

### DIFF
--- a/test/test_grudge_sym_old.py
+++ b/test/test_grudge_sym_old.py
@@ -143,11 +143,11 @@ def test_mass_mat_trig(actx_factory, ambient_dim, discr_tag):
 
     num_integral_1 = np.dot(ones_volm, actx.to_numpy(flatten(mass_op(f=f_quad))))
     err_1 = abs(num_integral_1 - true_integral)
-    assert err_1 < 1e-9, err_1
+    assert err_1 < 2e-9, err_1
 
     num_integral_2 = np.dot(f_volm, actx.to_numpy(flatten(mass_op(f=ones_quad))))
     err_2 = abs(num_integral_2 - true_integral)
-    assert err_2 < 3e-9, err_2
+    assert err_2 < 2e-9, err_2
 
     if discr_tag is dof_desc.DISCR_TAG_BASE:
         # NOTE: `integral` always makes a square mass matrix and

--- a/test/test_grudge_sym_old.py
+++ b/test/test_grudge_sym_old.py
@@ -147,7 +147,7 @@ def test_mass_mat_trig(actx_factory, ambient_dim, discr_tag):
 
     num_integral_2 = np.dot(f_volm, actx.to_numpy(flatten(mass_op(f=ones_quad))))
     err_2 = abs(num_integral_2 - true_integral)
-    assert err_2 < 1.0e-9, err_2
+    assert err_2 < 3e-9, err_2
 
     if discr_tag is dof_desc.DISCR_TAG_BASE:
         # NOTE: `integral` always makes a square mass matrix and


### PR DESCRIPTION
Example CI failure (observed on 9f587ca):

https://github.com/inducer/arraycontext/pull/29/checks?check_run_id=2853420098

```
=================================== FAILURES ===================================
_ test_mass_mat_trig[<array context factory for <pyopencl.Device 'pthread-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz' on 'Portable Computing Language'>-DISCR_TAG_BASE-3] _
[gw1] linux -- Python 3.9.4 /home/runner/work/arraycontext/arraycontext/grudge/.miniforge3/envs/testing/bin/python3
Traceback (most recent call last):
  File "/home/runner/work/arraycontext/arraycontext/grudge/test/test_grudge_sym_old.py", line 150, in test_mass_mat_trig
    assert err_2 < 1.0e-9, err_2
AssertionError: 1.6880221664905548e-09
assert 1.6880221664905548e-09 < 1e-09
_ test_mass_mat_trig[<array context factory for <pyopencl.Device 'pthread-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz' on 'Portable Computing Language'>-DISCR_TAG_QUAD-3] _
[gw1] linux -- Python 3.9.4 /home/runner/work/arraycontext/arraycontext/grudge/.miniforge3/envs/testing/bin/python3
Traceback (most recent call last):
  File "/home/runner/work/arraycontext/arraycontext/grudge/test/test_grudge_sym_old.py", line 150, in test_mass_mat_trig
    assert err_2 < 1.0e-9, err_2
AssertionError: 1.6952981241047382e-09
assert 1.6952981241047382e-09 < 1e-09
```
Interestingly, the corresponding tolerance in `test_grudge.py` had already been bumped up:
https://github.com/inducer/grudge/blob/9f587ca045cc9b56f5e63a61c0aa1319dfb039bf/test/test_grudge.py#L150-L157
So this PR makes the two consistent.

@thomasgibson Do you recall how that came about? I don't...