### PR TITLE
Refactor to track meshmode array context changes

### DIFF
--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -2,6 +2,11 @@ Helper functions
 ================
 
 Estimating stable time-steps
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 .. automodule:: grudge.dt_utils
+
+Array contexts
+--------------
+
+.. automodule:: grudge.array_context

--- a/examples/advection/surface.py
+++ b/examples/advection/surface.py
@@ -31,7 +31,8 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from meshmode.dof_array import flatten
 from meshmode.discretization.connection import FACE_RESTR_INTERIOR
@@ -106,7 +107,8 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     # {{{ parameters

--- a/examples/advection/var-velocity.py
+++ b/examples/advection/var-velocity.py
@@ -31,7 +31,8 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from meshmode.dof_array import flatten
 from meshmode.mesh import BTAG_ALL
@@ -103,7 +104,8 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     # {{{ parameters

--- a/examples/advection/weak.py
+++ b/examples/advection/weak.py
@@ -32,7 +32,8 @@ import numpy.linalg as la
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from meshmode.dof_array import flatten
 from meshmode.mesh import BTAG_ALL
@@ -103,7 +104,8 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     # {{{ parameters

--- a/examples/geometry.py
+++ b/examples/geometry.py
@@ -30,7 +30,8 @@ import numpy as np  # noqa
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from grudge import DiscretizationCollection, shortcuts
 
@@ -40,7 +41,8 @@ def main(write_output=True):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     from meshmode.mesh import BTAG_ALL

--- a/examples/maxwell/cavities.py
+++ b/examples/maxwell/cavities.py
@@ -30,7 +30,8 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from grudge.shortcuts import set_up_rk4
 from grudge import DiscretizationCollection
@@ -48,7 +49,8 @@ def main(ctx_factory, dim=3, order=4, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     from meshmode.mesh.generation import generate_regular_rect_mesh

--- a/examples/wave/var-propagation-speed.py
+++ b/examples/wave/var-propagation-speed.py
@@ -30,7 +30,8 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from grudge.shortcuts import set_up_rk4
 from grudge import DiscretizationCollection
@@ -48,7 +49,8 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     from meshmode.mesh.generation import generate_regular_rect_mesh

--- a/examples/wave/wave-min-mpi.py
+++ b/examples/wave/wave-min-mpi.py
@@ -30,7 +30,8 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from grudge.shortcuts import set_up_rk4
 from grudge import DiscretizationCollection
@@ -50,7 +51,8 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     comm = MPI.COMM_WORLD

--- a/examples/wave/wave-op-mpi.py
+++ b/examples/wave/wave-op-mpi.py
@@ -31,7 +31,8 @@ import numpy.linalg as la  # noqa
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from pytools.obj_array import flat_obj_array
 
@@ -145,7 +146,8 @@ def main(ctx_factory, dim=2, order=3, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     comm = MPI.COMM_WORLD

--- a/examples/wave/wave-op-var-velocity.py
+++ b/examples/wave/wave-op-var-velocity.py
@@ -31,7 +31,8 @@ import numpy.linalg as la  # noqa
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from grudge.array_context import PyOpenCLArrayContext
 
 from pytools.obj_array import flat_obj_array
 
@@ -162,7 +163,8 @@ def main(ctx_factory, dim=2, order=3, visualize=False):
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
         queue,
-        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue))
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)),
+        force_device_scalars=True,
     )
 
     nel_1d = 16

--- a/grudge/array_context.py
+++ b/grudge/array_context.py
@@ -1,0 +1,61 @@
+"""
+.. autoclass:: PyOpenCLArrayContext
+"""
+
+__copyright__ = "Copyright (C) 2020 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+from meshmode.array_context import PyOpenCLArrayContext as _PyOpenCLArrayContextBase
+from arraycontext.pytest import (
+        _PytestPyOpenCLArrayContextFactoryWithClass,
+        register_pytest_array_context_factory)
+
+
+class PyOpenCLArrayContext(_PyOpenCLArrayContextBase):
+    """Inherits from :class:`meshmode.array_context.PyOpenCLArrayContext`. Extends it
+    to understand :mod:`grudge`-specific transform metadata. (Of which there isn't
+    any, for now.)
+    """
+
+
+# {{{ pytest actx factory
+
+class PytestPyOpenCLArrayContextFactory(
+        _PytestPyOpenCLArrayContextFactoryWithClass):
+    actx_class = PyOpenCLArrayContext
+
+
+# deprecated
+class PytestPyOpenCLArrayContextFactoryWithHostScalars(
+        _PytestPyOpenCLArrayContextFactoryWithClass):
+    actx_class = PyOpenCLArrayContext
+    force_device_scalars = False
+
+
+register_pytest_array_context_factory("grudge.pyopencl",
+        PytestPyOpenCLArrayContextFactory)
+
+# }}}
+
+
+# vim: foldmethod=marker

--- a/grudge/dt_utils.py
+++ b/grudge/dt_utils.py
@@ -45,7 +45,8 @@ THE SOFTWARE.
 
 import numpy as np
 
-from arraycontext import ArrayContext, FirstAxisIsElementsTag, thaw, freeze
+from arraycontext import ArrayContext, thaw, freeze
+from meshmode.transform_metadata import FirstAxisIsElementsTag
 
 from grudge.dof_desc import DD_VOLUME, DOFDesc, as_dofdesc
 from grudge.discretization import DiscretizationCollection

--- a/grudge/models/wave.py
+++ b/grudge/models/wave.py
@@ -164,7 +164,7 @@ class WeakWaveOperator(HyperbolicOperator):
             )
         )
 
-        result[0] += self.source_f(actx, dcoll, t)
+        result[0] = result[0] + self.source_f(actx, dcoll, t)
 
         return result
 

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -80,13 +80,12 @@ def _norm(dcoll: DiscretizationCollection, vec, p, dd):
         return np.fabs(vec)
     if p == 2:
         from grudge.op import _apply_mass_operator
-        return np.real_if_close(np.sqrt(
+        return abs(
             nodal_sum(
                 dcoll,
                 dd,
-                vec.conj() * _apply_mass_operator(dcoll, dd, dd, vec)
-            )
-        ))
+                vec.conj() * _apply_mass_operator(dcoll, dd, dd, vec))
+            )**(1/2)
     elif p == np.inf:
         return nodal_max(dcoll, dd, abs(vec))
     else:
@@ -160,6 +159,7 @@ def nodal_sum_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
         return sum(nodal_sum_loc(dcoll, dd, vec[idx])
                    for idx in np.ndindex(vec.shape))
 
+    # FIXME: do not force result onto host
     actx = vec.array_context
     return sum([actx.np.sum(grp_ary) for grp_ary in vec])
 
@@ -178,9 +178,8 @@ def nodal_min(dcoll: DiscretizationCollection, dd, vec) -> float:
 
     # NOTE: Don't move this
     from mpi4py import MPI
-    actx = vec.array_context
 
-    return comm.allreduce(actx.to_numpy(nodal_min_loc(dcoll, dd, vec)), op=MPI.MIN)
+    return comm.allreduce(nodal_min_loc(dcoll, dd, vec), op=MPI.MIN)
 
 
 def nodal_min_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
@@ -197,8 +196,16 @@ def nodal_min_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
                    for idx in np.ndindex(vec.shape))
 
     actx = vec.array_context
-    return reduce(lambda acc, grp_ary: actx.np.minimum(acc, actx.np.min(grp_ary)),
-                  vec, np.inf)
+
+    # FIXME: do not force result onto host
+    # Host transfer is needed for now because actx.np.minimum does not succeed
+    # on array scalars.
+    # https://github.com/inducer/arraycontext/issues/49#issuecomment-869266944
+    return reduce(
+            lambda acc, grp_ary: actx.np.minimum(
+                acc,
+                actx.to_numpy(actx.np.min(grp_ary))[()]),
+            vec, np.inf)
 
 
 def nodal_max(dcoll: DiscretizationCollection, dd, vec) -> float:
@@ -215,9 +222,8 @@ def nodal_max(dcoll: DiscretizationCollection, dd, vec) -> float:
 
     # NOTE: Don't move this
     from mpi4py import MPI
-    actx = vec.array_context
 
-    return comm.allreduce(actx.to_numpy(nodal_max_loc(dcoll, dd, vec)), op=MPI.MAX)
+    return comm.allreduce(nodal_max_loc(dcoll, dd, vec), op=MPI.MAX)
 
 
 def nodal_max_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
@@ -234,8 +240,16 @@ def nodal_max_loc(dcoll: DiscretizationCollection, dd, vec) -> float:
                    for idx in np.ndindex(vec.shape))
 
     actx = vec.array_context
-    return reduce(lambda acc, grp_ary: actx.np.maximum(acc, actx.np.max(grp_ary)),
-                  vec, -np.inf)
+
+    # FIXME: do not force result onto host
+    # Host transfer is needed for now because actx.np.minimum does not succeed
+    # on array scalars.
+    # https://github.com/inducer/arraycontext/issues/49#issuecomment-869266944
+    return reduce(
+            lambda acc, grp_ary: actx.np.maximum(
+                acc,
+                actx.to_numpy(actx.np.max(grp_ary))[()]),
+            vec, -np.inf)
 
 
 def integral(dcoll: DiscretizationCollection, dd, vec) -> float:

--- a/test/test_dt_utils.py
+++ b/test/test_dt_utils.py
@@ -24,11 +24,12 @@ THE SOFTWARE.
 
 import numpy as np
 
-from arraycontext import (  # noqa
-    thaw,
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-)
+from arraycontext import thaw
+
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from grudge import DiscretizationCollection
 

--- a/test/test_grudge.py
+++ b/test/test_grudge.py
@@ -26,13 +26,13 @@ THE SOFTWARE.
 import numpy as np
 import numpy.linalg as la
 
-from arraycontext import (  # noqa
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-)
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
+
 from arraycontext.container.traversal import thaw
 
-from meshmode import _acf       # noqa: F401
 from meshmode.dof_array import flat_norm
 import meshmode.mesh.generation as mgen
 
@@ -241,7 +241,7 @@ def test_mass_surface_area(actx_factory, name):
 
         dd = dof_desc.DD_VOLUME
         ones_volm = volume_discr.zeros(actx) + 1
-        approx_surface_area = op.integral(dcoll, dd, ones_volm)
+        approx_surface_area = actx.to_numpy(op.integral(dcoll, dd, ones_volm))
 
         logger.info("surface: got {:.5e} / expected {:.5e}".format(
             approx_surface_area, surface_area))
@@ -318,7 +318,8 @@ def test_mass_operator_inverse(actx_factory, name):
             dcoll, op.mass(dcoll, dd, f_volm)
         )
 
-        inv_error = op.norm(dcoll, f_volm - f_inv, 2) / op.norm(dcoll, f_volm, 2)
+        inv_error = actx.to_numpy(
+                op.norm(dcoll, f_volm - f_inv, 2) / op.norm(dcoll, f_volm, 2))
 
         # }}}
 
@@ -455,7 +456,7 @@ def test_tri_diff_mat(actx_factory, dim, order=4):
             df_volm = df(x, axis)
 
             linf_error = flat_norm(df_num - df_volm, ord=np.inf)
-            axis_eoc_recs[axis].add_data_point(1/n, linf_error)
+            axis_eoc_recs[axis].add_data_point(1/n, actx.to_numpy(linf_error))
 
     for axis, eoc_rec in enumerate(axis_eoc_recs):
         logger.info("axis %d\n%s", axis, eoc_rec)
@@ -547,7 +548,7 @@ def test_surface_divergence_theorem(actx_factory, mesh_name, visualize=False):
 
     # }}}
 
-    # {{{ convergene
+    # {{{ convergence
 
     def f(x):
         return flat_obj_array(
@@ -635,7 +636,7 @@ def test_surface_divergence_theorem(actx_factory, mesh_name, visualize=False):
 
         h_max = h_max_from_volume(dcoll)
 
-        eoc_global.add_data_point(h_max, err_global)
+        eoc_global.add_data_point(h_max, actx.to_numpy(err_global))
         eoc_local.add_data_point(h_max, err_local)
 
         if visualize:
@@ -806,7 +807,7 @@ def test_convergence_advec(actx_factory, mesh_name, mesh_pars, op_type, flux_typ
             2
         )
         logger.info("h_max %.5e error %.5e", h_max, error_l2)
-        eoc_rec.add_data_point(h_max, error_l2)
+        eoc_rec.add_data_point(h_max, actx.to_numpy(error_l2))
 
     logger.info("\n%s", eoc_rec.pretty_print(
         abscissa_label="h",
@@ -887,7 +888,7 @@ def test_convergence_maxwell(actx_factory,  order):
 
         sol = analytic_sol(nodes, t=step * dt)
         total_error = op.norm(dcoll, esc - sol, 2)
-        eoc_rec.add_data_point(1.0/n, total_error)
+        eoc_rec.add_data_point(1.0/n, actx.to_numpy(total_error))
 
     logger.info("\n%s", eoc_rec.pretty_print(
         abscissa_label="h",
@@ -964,7 +965,7 @@ def test_improvement_quadrature(actx_factory, order):
             total_error = op.norm(
                 dcoll, adv_op.operator(0, gaussian_mode(nodes)), 2
             )
-            eoc_rec.add_data_point(1.0/n, total_error)
+            eoc_rec.add_data_point(1.0/n, actx.to_numpy(total_error))
 
         logger.info("\n%s", eoc_rec.pretty_print(
             abscissa_label="h",

--- a/test/test_grudge_sym_old.py
+++ b/test/test_grudge_sym_old.py
@@ -22,7 +22,6 @@ THE SOFTWARE.
 
 import numpy as np
 
-from meshmode import _acf       # noqa: F401
 from meshmode.dof_array import flatten, thaw
 import meshmode.mesh.generation as mgen
 
@@ -33,9 +32,11 @@ from grudge import sym, bind, DiscretizationCollection
 import grudge.dof_desc as dof_desc
 
 import pytest
-from meshmode.array_context import (  # noqa
-        pytest_generate_tests_for_pyopencl_array_context
-        as pytest_generate_tests)
+
+from grudge.array_context import PytestPyOpenCLArrayContextFactoryWithHostScalars
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactoryWithHostScalars])
 
 import logging
 

--- a/test/test_modal_connections.py
+++ b/test/test_modal_connections.py
@@ -21,11 +21,11 @@ THE SOFTWARE.
 """
 
 
-from arraycontext import (  # noqa
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-)
-from arraycontext.container.traversal import thaw
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
+from arraycontext import thaw
 
 from meshmode.discretization.poly_element import (
     # Simplex group factories

--- a/test/test_mpi_communication.py
+++ b/test/test_mpi_communication.py
@@ -30,7 +30,7 @@ import numpy as np
 import pyopencl as cl
 import logging
 
-from arraycontext.impl.pyopencl import PyOpenCLArrayContext
+from grudge.array_context import PyOpenCLArrayContext
 from arraycontext.container.traversal import thaw
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ import grudge.op as op
 def simple_mpi_communication_entrypoint():
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     from meshmode.distributed import MPIMeshDistributor, get_partition_by_pymetis
     from meshmode.mesh import BTAG_ALL
@@ -112,7 +112,7 @@ def simple_mpi_communication_entrypoint():
 def mpi_communication_entrypoint():
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD

--- a/test/test_op.py
+++ b/test/test_op.py
@@ -32,10 +32,11 @@ from grudge.dof_desc import DOFDesc
 
 import pytest
 
-from arraycontext import (  # noqa
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-)
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
+
 from arraycontext.container.traversal import thaw
 
 import logging

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -24,11 +24,12 @@ THE SOFTWARE.
 
 import numpy as np
 
-from arraycontext import (  # noqa
-    thaw,
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-)
+from arraycontext import thaw
+
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 from grudge import DiscretizationCollection
 

--- a/test/test_trace_pair.py
+++ b/test/test_trace_pair.py
@@ -27,10 +27,10 @@ import meshmode.mesh.generation as mgen
 
 from grudge import DiscretizationCollection
 
-from arraycontext import (  # noqa
-    pytest_generate_tests_for_pyopencl_array_context
-    as pytest_generate_tests
-)
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
 
 import logging
 


### PR DESCRIPTION
- Force device scalars in tests and examples
- Use meshmode transform metadata
- Give grudge its own array context, use it

@alexfikl, could you take a quick look once the tests pass?