### PR TITLE
More data reuse in differentiation

### DIFF
--- a/grudge/geometry/__init__.py
+++ b/grudge/geometry/__init__.py
@@ -32,6 +32,7 @@ from grudge.geometry.metrics import (
     inverse_first_fundamental_form,
 
     inverse_surface_metric_derivative,
+    inverse_surface_metric_derivative_mat,
     pseudoscalar,
     area_element,
 
@@ -51,6 +52,7 @@ __all__ = (
     "inverse_first_fundamental_form",
 
     "inverse_surface_metric_derivative",
+    "inverse_surface_metric_derivative_mat",
     "pseudoscalar",
     "area_element",
 

--- a/grudge/geometry/metrics.py
+++ b/grudge/geometry/metrics.py
@@ -385,6 +385,8 @@ def inverse_surface_metric_derivative(
     reference axis *rst_axis*. These geometric terms are used in the
     transformation of physical gradients.
 
+    This function does not cache its results.
+
     :arg rst_axis: an integer denoting the reference coordinate axis.
     :arg xyz_axis: an integer denoting the physical coordinate axis.
     :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
@@ -517,6 +519,8 @@ def area_element(
     r"""Computes the scale factor used to transform integrals from reference
     to global space.
 
+    This function caches its results.
+
     :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
         Defaults to the base volume discretization.
     :returns: a :class:`~meshmode.dof_array.DOFArray` containing the transformed
@@ -566,6 +570,8 @@ def mv_normal(
     (where ambient == topological dimension + 1). In the latter case, extra
     processing ensures that the returned normal is in the local tangent space
     of the element at the point where the normal is being evaluated.
+
+    This function caches its results.
 
     :arg dd: a :class:`~grudge.dof_desc.DOFDesc` as the surface discretization.
     :returns: a :class:`~pymbolic.geometric_algebra.MultiVector`
@@ -624,6 +630,8 @@ def normal(actx: ArrayContext, dcoll: DiscretizationCollection, dd):
     (where ambient == topological dimension + 1). In the latter case, extra
     processing ensures that the returned normal is in the local tangent space
     of the element at the point where the normal is being evaluated.
+
+    This function may be treated as if it caches its results.
 
     :arg dd: a :class:`~grudge.dof_desc.DOFDesc` as the surface discretization.
     :returns: an object array of :class:`~meshmode.dof_array.DOFArray`


### PR DESCRIPTION
Still to do:

- [x] Needs https://github.com/inducer/arraycontext/pull/87
- [x] Allow premultipling metric derivatives with jacobian
- [x] Pull xyz_axis into loopy kernel in grad
- [x] Pull xyz_axis into loopy kernel in weak grad
- [x] Unify weak and strong derivatives

cc @kaushikcfd 

Closes #144.