### PR TITLE
Entropy-stable DG: flux differencing and SBP operators

### DIFF
--- a/examples/euler/sod.py
+++ b/examples/euler/sod.py
@@ -205,7 +205,7 @@ def main(ctx_factory, order=4, visualize=False, esdg=False):
     def rhs(t, q):
         return euler_operator.operator(t, q)
 
-    dt = 1/100 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
+    dt = 1/4 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
 
     logger.info("Timestep size: %g", dt)
 

--- a/examples/euler/sod.py
+++ b/examples/euler/sod.py
@@ -98,7 +98,7 @@ class Plotter:
 # }}}
 
 
-def main(ctx_factory, dim=1, order=4, visualize=False):
+def main(ctx_factory, dim=1, order=4, visualize=False, esdg=False):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
@@ -184,9 +184,15 @@ def main(ctx_factory, dim=1, order=4, visualize=False):
     nodes = thaw(dcoll.nodes(), actx)
     q_init = sod_initial_condition(nodes)
 
-    from grudge.models.euler import EntropyStableEulerOperator
+    from grudge.models.euler import \
+        EntropyStableEulerOperator, EulerOperator
 
-    euler_operator = EntropyStableEulerOperator(
+    if esdg:
+        operator_cls = EntropyStableEulerOperator
+    else:
+        operator_cls = EulerOperator
+
+    euler_operator = operator_cls(
         dcoll,
         bdry_fcts={BTAG_ALL: sod_initial_condition},
         flux_type=flux_type,
@@ -234,9 +240,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--order", default=4, type=int)
     parser.add_argument("--visualize", action="store_true")
+    parser.add_argument("--esdg", action="store_true")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
     main(cl.create_some_context,
          order=args.order,
-         visualize=args.visualize)
+         visualize=args.visualize,
+         esdg=args.esdg)

--- a/examples/euler/sod.py
+++ b/examples/euler/sod.py
@@ -98,7 +98,7 @@ class Plotter:
 # }}}
 
 
-def main(ctx_factory, dim=1, order=4, visualize=False, esdg=False):
+def main(ctx_factory, order=4, visualize=False, esdg=False):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
@@ -109,10 +109,12 @@ def main(ctx_factory, dim=1, order=4, visualize=False, esdg=False):
 
     # {{{ parameters
 
+    dim = 1
+
     # domain [0, 1]
     d = 1.0
     # number of points in each dimension
-    npoints = 100
+    npoints = 25
 
     # final time
     final_time = 0.2
@@ -143,7 +145,7 @@ def main(ctx_factory, dim=1, order=4, visualize=False, esdg=False):
         actx, mesh,
         discr_tag_to_group_factory={
             DISCR_TAG_BASE: default_simplex_group_factory(dim, order),
-            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order)
+            DISCR_TAG_QUAD: default_simplex_group_factory(dim, order)
         }
     )
 
@@ -203,7 +205,7 @@ def main(ctx_factory, dim=1, order=4, visualize=False, esdg=False):
     def rhs(t, q):
         return euler_operator.operator(t, q)
 
-    dt = 1/10 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
+    dt = 1/100 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
 
     logger.info("Timestep size: %g", dt)
 

--- a/examples/euler/sod.py
+++ b/examples/euler/sod.py
@@ -97,52 +97,52 @@ class Plotter:
         fig, axs = plt.subplots(2, 2, sharex=True)
 
         axs[0, 0].plot(self.x, density, ":",
-                       marker='o',
-                       label='density',
+                       marker="o",
+                       label="density",
                        linewidth=linewidth,
                        markersize=markersize)
         axs[1, 0].plot(self.x, pressure, ":",
-                       marker='o',
-                       label='pressure',
+                       marker="o",
+                       label="pressure",
                        linewidth=linewidth,
                        markersize=markersize)
         axs[0, 1].plot(self.x, velocity, ":",
-                       marker='o',
-                       label='velocity',
+                       marker="o",
+                       label="velocity",
                        linewidth=linewidth,
                        markersize=markersize)
         axs[1, 1].plot(self.x, energy, ":",
-                       marker='o',
-                       label='energy',
+                       marker="o",
+                       label="energy",
                        linewidth=linewidth,
                        markersize=markersize)
 
         # if self.ylim is not None:
         #     ax.set_ylim(self.ylim)
-        # ax.legend(prop={'size': fontsize})
+        # ax.legend(prop={"size": fontsize})
 
         axs[0, 0].set_xlabel("$x$", fontsize=fontsize)
         axs[0, 0].set_ylabel("$\\rho$", fontsize=fontsize)
-        # axs[0, 0].tick_params(axis='x', labelsize=fontsize)
-        # axs[0, 0].tick_params(axis='y', labelsize=fontsize)
+        # axs[0, 0].tick_params(axis="x", labelsize=fontsize)
+        # axs[0, 0].tick_params(axis="y", labelsize=fontsize)
         axs[1, 0].set_xlabel("$x$", fontsize=fontsize)
         axs[1, 0].set_ylabel("$p$", fontsize=fontsize)
-        # axs[1, 0].tick_params(axis='x', labelsize=fontsize)
-        # axs[1, 0].tick_params(axis='y', labelsize=fontsize)
+        # axs[1, 0].tick_params(axis="x", labelsize=fontsize)
+        # axs[1, 0].tick_params(axis="y", labelsize=fontsize)
         axs[0, 1].set_xlabel("$x$", fontsize=fontsize)
         axs[0, 1].set_ylabel("$u$", fontsize=fontsize)
-        # axs[0, 1].tick_params(axis='x', labelsize=fontsize)
-        # axs[0, 1].tick_params(axis='y', labelsize=fontsize)
+        # axs[0, 1].tick_params(axis="x", labelsize=fontsize)
+        # axs[0, 1].tick_params(axis="y", labelsize=fontsize)
         axs[1, 1].set_xlabel("$x$", fontsize=fontsize)
         axs[1, 1].set_ylabel("$\\rho e$", fontsize=fontsize)
-        # axs[1, 1].tick_params(axis='x', labelsize=fontsize)
-        # axs[1, 1].tick_params(axis='y', labelsize=fontsize)
+        # axs[1, 1].tick_params(axis="x", labelsize=fontsize)
+        # axs[1, 1].tick_params(axis="y", labelsize=fontsize)
         fig.suptitle(
             f"N = {self.order}, Npt = {self.npoints}, t = {t:.3f}",
             fontsize=fontsize
         )
 
-        fig.savefig(filename, bbox_inches='tight')
+        fig.savefig(filename, bbox_inches="tight")
         fig.clf()
 
 # }}}
@@ -273,12 +273,11 @@ def main(ctx_factory, order=4, visualize=False, overintegration=False):
     # {{{ time stepping
 
     step = 0
-    norm_q = 0.0
     t = 0.0
     while t < final_time:
         fields = rk4_step(fields, t, dt, rhs)
 
-        if step % 10 == 0:
+        if step % 1 == 0:
             l2norm = actx.to_numpy(op.norm(dcoll, fields.join(), 2))
             logger.info(f"step: {step} t: {t} norm(q) = {l2norm}")
             plot(fields, "fld-sod-%04d" % step, t=t)

--- a/examples/euler/sod.py
+++ b/examples/euler/sod.py
@@ -206,12 +206,12 @@ def main(ctx_factory, dim=1, order=4, visualize=False):
         if not isinstance(event, dt_stepper.StateComputed):
             continue
 
-        # if step % 1 == 0:
-        #     norm_q = actx.to_numpy(op.norm(dcoll, event.state_component, 2))
-        #     plot(event, "fld-sod-%04d" % step)
+        if step % 1 == 0:
+            norm_q = actx.to_numpy(op.norm(dcoll, event.state_component, 2))
+            plot(event, "fld-sod-%04d" % step)
 
-        # step += 1
-        # logger.info("[%04d] t = %.5f |q| = %.5e", step, event.t, norm_q)
+        step += 1
+        logger.info("[%04d] t = %.5f |q| = %.5e", step, event.t, norm_q)
 
         assert norm_q < 100
 

--- a/examples/euler/sod.py
+++ b/examples/euler/sod.py
@@ -170,12 +170,12 @@ def main(ctx_factory, dim=1, order=4, visualize=False):
 
         return ArrayContainer(mass=mass,
                               energy=energy,
-                              momentum=mom)
+                              momentum=mom).join()
 
     nodes = thaw(dcoll.nodes(), actx)
     q_init = sod_initial_condition(nodes)
 
-    from grudge.models.euler import EulerOperator, EntropyStableEulerOperator
+    from grudge.models.euler import EntropyStableEulerOperator
 
     euler_operator = EntropyStableEulerOperator(
         dcoll,
@@ -197,7 +197,7 @@ def main(ctx_factory, dim=1, order=4, visualize=False):
     # {{{ time stepping
 
     from grudge.shortcuts import set_up_rk4
-    dt_stepper = set_up_rk4("q", dt, q_init.join(), rhs)
+    dt_stepper = set_up_rk4("q", dt, q_init, rhs)
     plot = Plotter(actx, dcoll, order, visualize=visualize, ylim=[0.0, 1.2])
 
     step = 0

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -99,7 +99,7 @@ class Plotter:
 # }}}
 
 
-def main(ctx_factory, dim=2, order=4, visualize=False):
+def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
@@ -185,9 +185,15 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
 
         return result
 
-    from grudge.models.euler import EntropyStableEulerOperator
+    from grudge.models.euler import \
+        EntropyStableEulerOperator, EulerOperator
 
-    euler_operator = EntropyStableEulerOperator(
+    if esdg:
+        operator_cls = EntropyStableEulerOperator
+    else:
+        operator_cls = EulerOperator
+
+    euler_operator = operator_cls(
         dcoll,
         bdry_fcts={BTAG_ALL: vortex_initial_condition},
         flux_type=flux_type,
@@ -258,9 +264,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--order", default=4, type=int)
     parser.add_argument("--visualize", action="store_true")
+    parser.add_argument("--esdg", action="store_true")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
     main(cl.create_some_context,
          order=args.order,
-         visualize=args.visualize)
+         visualize=args.visualize,
+         esdg=args.esdg)

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -137,8 +137,18 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
         nelements_per_axis=(nel_1d,)*dim)
 
     from grudge import DiscretizationCollection
+    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
+    from meshmode.discretization.poly_element import \
+        (PolynomialWarpAndBlend2DRestrictingGroupFactory,
+         QuadratureSimplexGroupFactory)
 
-    dcoll = DiscretizationCollection(actx, mesh, order=order)
+    dcoll = DiscretizationCollection(
+        actx, mesh,
+        discr_tag_to_group_factory={
+            DISCR_TAG_BASE: PolynomialWarpAndBlend2DRestrictingGroupFactory(order),
+            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order)
+        }
+    )
 
     # }}}
 

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -114,7 +114,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
     nel_1d = 16
 
     # final time
-    final_time = 0.2
+    final_time = 1
 
     # flux
     flux_type = "lf"
@@ -205,7 +205,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
         return euler_operator.operator(t, q)
 
     q_init = vortex_initial_condition(thaw(dcoll.nodes(), actx))
-    dt = 1/10 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
+    dt = 1/2 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
 
     logger.info("Timestep size: %g", dt)
 
@@ -220,9 +220,9 @@ def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
         vis.write_vtk_file(
             f"fld-vortex-{step:04d}.vtu",
             [
-                ("rho", q_init.mass),
-                ("energy", q_init.energy),
-                ("momentum", q_init.momentum),
+                ("rho", q_init[0]),
+                ("energy", q_init[1]),
+                ("momentum", q_init[2:]),
             ]
         )
 

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -99,7 +99,7 @@ class Plotter:
 # }}}
 
 
-def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
+def main(ctx_factory, dim=2, order=3, visualize=False, esdg=False):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(
@@ -111,13 +111,13 @@ def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
     # {{{ parameters
 
     # number of points in each dimension
-    nel_1d = 16
+    nel_1d = 8
 
     # final time
     final_time = 1
 
     # flux
-    flux_type = "lf"
+    flux_type = "central"
 
     # eos-related parameters
     gamma = 1.4
@@ -263,7 +263,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--order", default=4, type=int)
+    parser.add_argument("--order", default=3, type=int)
     parser.add_argument("--visualize", action="store_true")
     parser.add_argument("--esdg", action="store_true")
     args = parser.parse_args()

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -178,11 +178,12 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
 
         energy = p / (gamma - 1) + mass / 2 * (u ** 2 + v ** 2)
 
-        from grudge.models.euler import ArrayContainer
+        result = np.empty((2+dim,), dtype=object)
+        result[0] = mass
+        result[1] = energy
+        result[2:dim+2] = momentum
 
-        return ArrayContainer(mass=mass,
-                              energy=energy,
-                              momentum=momentum).join()
+        return result
 
     from grudge.models.euler import EntropyStableEulerOperator
 

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -172,9 +172,9 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
 
         return ArrayContainer(mass=mass,
                               energy=energy,
-                              momentum=momentum)
+                              momentum=momentum).join()
 
-    from grudge.models.euler import EulerOperator, EntropyStableEulerOperator
+    from grudge.models.euler import EntropyStableEulerOperator
 
     euler_operator = EntropyStableEulerOperator(
         dcoll,
@@ -212,7 +212,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
     # {{{ time stepping
 
     from grudge.shortcuts import set_up_rk4
-    dt_stepper = set_up_rk4("q", dt, q_init.join(), rhs)
+    dt_stepper = set_up_rk4("q", dt, q_init, rhs)
 
     norm_q = 0.0
     for event in dt_stepper.run(t_end=final_time):

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -196,6 +196,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
     euler_operator = operator_cls(
         dcoll,
         bdry_fcts={BTAG_ALL: vortex_initial_condition},
+        initial_condition=vortex_initial_condition,
         flux_type=flux_type,
         gamma=gamma,
         gas_const=gas_const,
@@ -205,7 +206,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False, esdg=False):
         return euler_operator.operator(t, q)
 
     q_init = vortex_initial_condition(thaw(dcoll.nodes(), actx))
-    dt = 1/2 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
+    dt = 2/3 * euler_operator.estimate_rk4_timestep(actx, dcoll, state=q_init)
 
     logger.info("Timestep size: %g", dt)
 

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -726,7 +726,9 @@ class EntropyStableEulerOperator(EulerOperator):
         # and the inverse mass matrix
         # du = M.inv * (-∑_d [V_q; V_f].T (2Q_d * F_d)1
         #               -V_f.T B_d (f*_d - f(q_f)))
-        dqhat = op.inverse_mass(dcoll, -QF_q - op.face_mass(dcoll, num_flux_bnd))
+        from grudge.sbp_op import inverse_sbp_mass
+
+        dqhat = inverse_sbp_mass(dcoll, -QF_q - op.face_mass(dcoll, num_flux_bnd))
         print("Finished applying mass and lifting operators.")
 
         print("Converting state arrays to nodal data...")

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -226,9 +226,45 @@ class EulerState:
     def dim(self):
         return len(self.momentum)
 
-    @property
-    def velocity(self):
-        return self.momentum / self.mass
+    def join(self):
+        return _join_fields(
+            dim=self.dim,
+            mass=self.mass,
+            energy=self.energy,
+            momentum=self.momentum
+        )
+
+
+def _join_fields(dim, mass, energy, momentum):
+    def _aux_shape(ary, leading_shape):
+        from meshmode.dof_array import DOFArray
+        if (isinstance(ary, np.ndarray) and ary.dtype == object
+                and not isinstance(ary, DOFArray)):
+            naxes = len(leading_shape)
+            if ary.shape[:naxes] != leading_shape:
+                raise ValueError("array shape does not start with expected leading "
+                        "dimensions")
+            return ary.shape[naxes:]
+        else:
+            if leading_shape != ():
+                raise ValueError("array shape does not start with expected leading "
+                        "dimensions")
+            return ()
+
+    aux_shapes = [
+        _aux_shape(mass, ()),
+        _aux_shape(energy, ()),
+        _aux_shape(momentum, (dim,))]
+
+    from pytools import single_valued
+    aux_shape = single_valued(aux_shapes)
+
+    result = np.empty((2+dim,) + aux_shape, dtype=object)
+    result[0] = mass
+    result[1] = energy
+    result[2:dim+2] = momentum
+
+    return result
 
 
 def conservative_to_entropy_vars(actx, dcoll, cv_state, gamma=1.4):
@@ -305,20 +341,7 @@ def entropy_projection(
     return aux_cv_state_q, ev_state
 
 
-def _reshape(dcoll, shape, vec):
-    if not isinstance(vec, DOFArray):
-        return map_array_container(partial(_reshape, dcoll, shape), vec)
-
-    return DOFArray(
-        vec.array_context,
-        data=tuple(
-            vec_i.reshape(grp.nelements, *shape)
-            for grp, vec_i in zip(dcoll.discr_from_dd("vol").groups, vec)
-        )
-    )
-
-
-def flux_chandrashekar(dcoll, qi, qj, gamma=1.4, use_numpy=False):
+def flux_chandrashekar(dcoll, gamma, use_numpy, qi, qj):
     """Entropy conserving two-point flux by Chandrashekar (2013)
     Kinetic Energy Preserving and Entropy Stable Finite Volume Schemes
     for Compressible Euler and Navier-Stokes Equations
@@ -402,188 +425,6 @@ def flux_chandrashekar(dcoll, qi, qj, gamma=1.4, use_numpy=False):
     )
 
 
-def volume_flux_differencing(actx, dcoll, dq, df, state, gamma=1.4):
-    """Computes the flux differencing operation: ∑_j 2Q[i, j] * f_S(q_i, q_j),
-    where Q is a hybridized SBP derivative matrix and f_S is
-    an entropy-conservative two-point flux.
-
-    See `flux_chandrashekar` for a concrete implementation of such a two-point
-    flux routine.
-    """
-    from grudge.sbp_op import \
-        hybridized_sbp_operators, volume_and_surface_quadrature_interpolation
-    from grudge.geometry import area_element, inverse_metric_derivative_mat
-
-    mesh = dcoll.mesh
-    dim = dcoll.dim
-    dtype = state[0].entry_dtype
-
-    volm_discr = dcoll.discr_from_dd("vol")
-    face_discr = dcoll.discr_from_dd("all_faces")
-    volm_quad_discr = dcoll.discr_from_dd(dq)
-    face_quad_discr = dcoll.discr_from_dd(df)
-
-    # Geometry terms for building the physical derivative operators
-    # (interpolated to volume+surface quadrature nodes)
-    jacobian_dets = volume_and_surface_quadrature_interpolation(
-        dcoll, dq, df, area_element(actx, dcoll)
-    )
-    drstdxyz = volume_and_surface_quadrature_interpolation(
-        dcoll, dq, df, inverse_metric_derivative_mat(actx, dcoll)
-    )
-    rstxyzj = jacobian_dets * drstdxyz
-
-    rho = state[0]
-    rhoe = state[1]
-    rhou = state[2:dim+2]
-
-    # Group array lists for the computed result
-    QF_mass_data = []
-    QF_energy_data = []
-    QF_momentum_data = []
-
-    # Group loop
-    for gidx, mgrp in enumerate(mesh.groups):
-        vgrp = volm_discr.groups[gidx]
-        vqgrp = volm_quad_discr.groups[gidx]
-        fqgrp = face_quad_discr.groups[gidx]
-
-        Nelements = mgrp.nelements
-        Nq_vol = vqgrp.nunit_dofs
-        Nq_faces = vqgrp.shape.nfaces * fqgrp.nunit_dofs
-        Nq_total = Nq_vol + Nq_faces
-
-        # Get geometric terms for the group
-        vgeo_gidx = [[actx.to_numpy(rstxyzj[ridx][cidx][gidx])
-                      for ridx in range(dim)]
-                     for cidx in range(dim)]
-
-        # Get state values for the group
-        rho_gidx = rho[gidx]
-        rhoe_gidx = rhoe[gidx]
-        rhou_gidx = [ru[gidx] for ru in rhou]
-
-        # Form skew-symmetric SBP hybridized derivative operators
-        qmats = actx.to_numpy(
-            thaw(hybridized_sbp_operators(actx,
-                                          vgrp,
-                                          vqgrp, fqgrp,
-                                          dtype), actx)
-        )
-        Qrst_skew = [0.5 * (qmats[d] - qmats[d].T) for d in range(dim)]
-
-        # Group arrays for the Hadamard row-sum
-        dQF_rho = np.zeros(shape=(Nelements, Nq_total), dtype=dtype)
-        dQF_rhoe = np.zeros(shape=(Nelements, Nq_total), dtype=dtype)
-        dQF_rhou = np.zeros(shape=(dim, Nelements, Nq_total), dtype=dtype)
-
-        # Element loop
-        for eidx in range(Nelements):
-            vgeo = [[vgeo_gidx[ridx][cidx][eidx]
-                     for ridx in range(dim)]
-                    for cidx in range(dim)]
-
-            # Build physical SBP operators on the element
-            Qxyz_skew = [
-                2*sum(vgeo[j][d] * Qrst_skew[j] for j in range(dim))
-                for d in range(dim)
-            ]
-
-            # Element-local state data
-            local_rho = actx.to_numpy(rho_gidx[eidx])
-            local_rhoe = actx.to_numpy(rhoe_gidx[eidx])
-            local_rhou = np.array(
-                [actx.to_numpy(rhou_gidx[d][eidx]) for d in range(dim)]
-            )
-
-            # Local arrays for the Hadamard row-sum
-            dq_rho = np.zeros(shape=(Nq_total,))
-            dq_rhoe = np.zeros(shape=(Nq_total,))
-            dq_rhou = np.zeros(shape=(dim, Nq_total))
-
-            # Compute flux differencing in each cell and apply the
-            # hybridized SBP operator
-            for d in range(dim):
-                Qskew_d = Qxyz_skew[d]
-                # Loop over all (vol + surface) quadrature nodes and compute
-                # the Hadamard row-sum
-                for i in range(Nq_total):
-                    q_i = (local_rho[i],
-                           local_rhoe[i],
-                           local_rhou[:, i])
-
-                    dq_rho_i = dq_rho[i]
-                    dq_rhoe_i = dq_rhoe[i]
-                    dq_rhou_i = dq_rhou[:, i]
-
-                    # Loop over all (vol + surface) quadrature nodes
-                    for j in range(Nq_total):
-                        # Computes only the upper-triangular part of the
-                        # hadamard sum (Q .* F). We avoid computing the
-                        # lower-triangular part using the fact that Q is
-                        # skew-symmetric and F is symmetric.
-                        # Also skips subblock of Q which we know is
-                        # zero by construction.
-                        if j > i and not (i > Nq_vol and j > Nq_vol):
-                            # Apply derivative to each component
-                            # (mass, energy, momentum)
-                            QF_rho_ij, QF_rhoe_ij, QF_rhou_ij = \
-                                Qskew_d[i, j] * flux_chandrashekar(
-                                    q_i,
-                                    (local_rho[j], local_rhoe[j], local_rhou[:, j]),
-                                    d,
-                                    gamma=gamma
-                                )
-
-                            # Accumulate upper triangular part
-                            dq_rho_i = dq_rho_i + QF_rho_ij
-                            dq_rhoe_i = dq_rhoe_i + QF_rhoe_ij
-                            dq_rhou_i = dq_rhou_i + QF_rhou_ij
-
-                            # Accumulate lower triangular part
-                            dq_rho[j] = dq_rho[j] - QF_rho_ij
-                            dq_rhoe[j] = dq_rhoe[j] - QF_rhoe_ij
-                            dq_rhou[:, j] = dq_rhou[:, j] - QF_rhou_ij
-                        # end if
-                    # end j
-                    dq_rho[i] = dq_rho_i
-                    dq_rhoe[i] = dq_rhoe_i
-                    dq_rhou[:, i] = dq_rhou_i
-                # end i
-            # end d
-            dQF_rho[eidx, :] = dq_rho
-            dQF_rhoe[eidx, :] = dq_rhoe
-            dQF_rhou[:, eidx, :] = dq_rhou
-        # end e
-
-        # Append group data
-        QF_mass_data.append(actx.from_numpy(dQF_rho))
-        QF_energy_data.append(actx.from_numpy(dQF_rhoe))
-        QF_momentum_data.append([actx.from_numpy(dQF_rhou[d])
-                                 for d in range(dim)])
-    # end g
-
-    # Convert back to mirgecom-like data structure
-    QF_mass_dof_ary = DOFArray(actx, data=tuple(QF_mass_data))
-    QF_energy_dof_ary = DOFArray(actx, data=tuple(QF_energy_data))
-    QF_momentum_dof_ary = make_obj_array(
-        [DOFArray(actx,
-                  data=tuple(mom_data[d]
-                             for mom_data in QF_momentum_data))
-                  for d in range(dim)]
-    )
-
-    result = np.empty((2+dim,), dtype=object)
-    result[0] = QF_mass_dof_ary
-    result[1] = QF_energy_dof_ary
-    result[2:dim+2] = QF_momentum_dof_ary
-
-    from grudge.sbp_op import volume_and_surface_quadrature_projection
-
-    # Apply Ph = Minv * [Vq @ Wq; Vf @ Wf].T to the result
-    return volume_and_surface_quadrature_projection(dcoll, dq, df, result)
-
-
 def entropy_stable_numerical_flux_chandrashekar(
         dcoll, tpair, gamma=1.4, lf_stabilization=False):
     """Entropy stable numerical flux based on the entropy conserving flux in
@@ -596,13 +437,26 @@ def entropy_stable_numerical_flux_chandrashekar(
     dd_allfaces = dd_intfaces.with_dtag("all_faces")
     q_int = tpair.int
     q_ext = tpair.ext
+    actx = q_int.array_context
 
-    flux = flux_chandrashekar(dcoll, q_int, q_ext, gamma=gamma)
+    flux = flux_chandrashekar(dcoll, gamma, False, q_int, q_ext)
     normal = thaw(dcoll.normal(dd_intfaces), actx)
     num_flux = flux @ normal
 
     if lf_stabilization:
         # compute jump penalization parameter
+        # FIXME: Move into *flux_chandrashekar*
+        rho_int = q_int.mass
+        rhoe_int = q_int.energy
+        rhou_int = q_int.momentum
+        rho_ext = q_ext.mass
+        rhoe_ext = q_ext.energy
+        rhou_ext = q_ext.momentum
+        v_int = rhou_int / rho_int
+        v_ext = rhou_ext / rho_ext
+        p_int = (gamma - 1) * (rhoe_int - 0.5 * sum(rhou_int * v_int))
+        p_ext = (gamma - 1) * (rhoe_ext - 0.5 * sum(rhou_ext * v_ext))
+
         lam = actx.np.maximum(
             actx.np.sqrt(gamma * (p_int / rho_int))
             + actx.np.sqrt(np.dot(v_int, v_int)),
@@ -619,7 +473,7 @@ def entropy_stable_boundary_numerical_flux_prescribed(
         gamma=1.4, t=0.0, lf_stabilization=False):
     """todo.
     """
-    actx = proj_ev_state[0].array_context
+    actx = proj_ev_state.array_context
     x_bcq = thaw(dcoll.nodes(dd_bcq), actx)
     ev_bcq = op.project(dcoll, "vol", dd_bcq, proj_ev_state)
     bdry_tpair = TracePair(
@@ -659,14 +513,13 @@ class EntropyStableEulerOperator(EulerOperator):
 
         print("Performing volume flux differencing...")
 
-        flux_evals = flux_chandrashekar(
+        from grudge.sbp_op import volume_flux_differencing
+
+        dQF1 = volume_flux_differencing(
             dcoll,
-            # Using numpy broadcasting
-            to_numpy(_reshape(dcoll, (1, -1), qtilde_allquad), actx),
-            to_numpy(_reshape(dcoll, (-1, 1), qtilde_allquad), actx),
-            gamma=gamma,
-            # Using numpy broadcasting
-            use_numpy=True
+            partial(flux_chandrashekar, dcoll, gamma, True),
+            dq, df,
+            qtilde_allquad
         )
 
         print("Computing interface numerical fluxes...")
@@ -716,8 +569,9 @@ class EntropyStableEulerOperator(EulerOperator):
         # Compute: sum_i={x,y,z} (Minv @ V_f.T @ Wf @ Jf_i) * f_i
         # Lift operator: Minv @ V_f.T @ Wf
         lifted_fluxes = inverse_sbp_mass(
-            dcoll, dq, op.face_mass(dcoll, df, num_fluxes_bdry))
+            dcoll, dq, op.face_mass(dcoll, df, num_fluxes_bdry.join()))
         print("Finished applying lifting operators.")
+        import ipdb; ipdb.set_trace()
 
         from grudge.geometry import area_element
         # Apply inverse cell jacobians

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -741,14 +741,12 @@ class EntropyStableEulerOperator(EulerOperator):
         #               -V_f.T B_d (f*_d - f(q_f)))
         from grudge.sbp_op import inverse_sbp_mass, sbp_lift_operator
 
-        dqhat = inverse_sbp_mass(dcoll, -VhTQF1 - sbp_lift_operator(dcoll, f_bdry))
+        VfTBFbdry = sbp_lift_operator(dcoll, df, f_bdry)
+        dqhat = inverse_sbp_mass(dcoll, dq, -VhTQF1 - VfTBFbdry)
         print("Finished applying mass and lifting operators.")
 
-        print("Converting state arrays to nodal data...")
-        # NOTE: Convert data back to nodal
-        dq = self.map_to_nodal(dqhat)
-        print("Finished converting state arrays.")
+        1/0
 
-        return dq
+        return dqhat
 
 # }}}

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -710,7 +710,7 @@ class EntropyStableEulerOperator(EulerOperator):
         # elements, plus the surface contribution from the flux differencing:
         # QF_f + V_f.T B_i (f*_i - f(q_f))
         nodes = thaw(dcoll.nodes(), actx)
-        num_flux_bnd = QF_f + (
+        f_bdry = QF_f + (
             sum(self.numerical_flux(tpair)
                 for tpair in op.interior_trace_pairs(dcoll, qhat))
             - sum(
@@ -726,9 +726,9 @@ class EntropyStableEulerOperator(EulerOperator):
         # and the inverse mass matrix
         # du = M.inv * (-∑_d [V_q; V_f].T (2Q_d * F_d)1
         #               -V_f.T B_d (f*_d - f(q_f)))
-        from grudge.sbp_op import inverse_sbp_mass
+        from grudge.sbp_op import inverse_sbp_mass, sbp_lift_operator
 
-        dqhat = inverse_sbp_mass(dcoll, -QF_q - op.face_mass(dcoll, num_flux_bnd))
+        dqhat = inverse_sbp_mass(dcoll, -QF_q - sbp_lift_operator(dcoll, f_bdry))
         print("Finished applying mass and lifting operators.")
 
         print("Converting state arrays to nodal data...")

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -488,7 +488,7 @@ def flux_chandrashekar(q_ll, q_rr, orientation, gamma=1.4):
 
 
 def flux_differencing_kernel(actx, dcoll, quad_state, gamma=1.4):
-    """Computes the flux differencing operation: ∑_j Q[i, j] * f_S(q_i, q_j),
+    """Computes the flux differencing operation: ∑_j 2Q[i, j] * f_S(q_i, q_j),
     where Q is a hybridized SBP derivative matrix and f_S is
     an entropy-conservative two-point flux.
 
@@ -580,9 +580,9 @@ def flux_differencing_kernel(actx, dcoll, quad_state, gamma=1.4):
                         f_mass, f_energy, f_momentum = \
                             flux_chandrashekar(q_i, q_j, d, gamma=gamma)
 
-                        QF_mass[eidx, i] += Q[i, j] * f_mass
-                        QF_energy[eidx, i] += Q[i, j] * f_energy
-                        QF_momentum[:, eidx, i] += Q[i, j] * f_momentum
+                        QF_mass[eidx, i] += 2*Q[i, j] * f_mass
+                        QF_energy[eidx, i] += 2*Q[i, j] * f_energy
+                        QF_momentum[:, eidx, i] += 2*Q[i, j] * f_momentum
 
         # Append group data
         QF_mass_data.append(actx.from_numpy(QF_mass))

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -395,7 +395,6 @@ def volume_flux_differencing(actx, dcoll, dq, df, state, gamma=1.4):
     # Group loop
     for gidx, mgrp in enumerate(mesh.groups):
         vgrp = volm_discr.groups[gidx]
-        fgrp = face_discr.groups[gidx]
         vqgrp = volm_quad_discr.groups[gidx]
         fqgrp = face_quad_discr.groups[gidx]
 
@@ -435,8 +434,10 @@ def volume_flux_differencing(actx, dcoll, dq, df, state, gamma=1.4):
                     for cidx in range(dim)]
 
             # Build physical SBP operators on the element
-            Qxyz_skew = [2*vgeo[j][d] * Qrst_skew[j]
-                         for j in range(dim) for d in range(dim)]
+            Qxyz_skew = [
+                2*sum(vgeo[j][d] * Qrst_skew[j] for j in range(dim))
+                for d in range(dim)
+            ]
 
             # Element-local state data
             local_rho = actx.to_numpy(rho_gidx[eidx])

--- a/grudge/models/euler.py
+++ b/grudge/models/euler.py
@@ -512,7 +512,6 @@ class EntropyStableEulerOperator(EulerOperator):
         print("Finished auxiliary conservative variables.")
 
         print("Performing volume flux differencing...")
-
         from grudge.sbp_op import volume_flux_differencing
 
         dQF1 = volume_flux_differencing(
@@ -521,6 +520,7 @@ class EntropyStableEulerOperator(EulerOperator):
             dq, df,
             qtilde_allquad
         )
+        print("Finished volume flux differencing.")
 
         print("Computing interface numerical fluxes...")
         def entropy_tpair(tpair):
@@ -566,15 +566,13 @@ class EntropyStableEulerOperator(EulerOperator):
         print("Applying lifting operators...")
         from grudge.sbp_op import inverse_sbp_mass
 
-        # Compute: sum_i={x,y,z} (Minv @ V_f.T @ Wf @ Jf_i) * f_i
-        # Lift operator: Minv @ V_f.T @ Wf
+
         lifted_fluxes = inverse_sbp_mass(
-            dcoll, dq, op.face_mass(dcoll, df, num_fluxes_bdry.join()))
+            dcoll, dq, op.face_mass(dcoll, df, num_fluxes_bdry))
         print("Finished applying lifting operators.")
-        import ipdb; ipdb.set_trace()
 
         from grudge.geometry import area_element
-        # Apply inverse cell jacobians
+
         inv_jacobians = 1./area_element(actx, dcoll)
 
         return -inv_jacobians*(dQF1 + lifted_fluxes)

--- a/grudge/sbp_op.py
+++ b/grudge/sbp_op.py
@@ -36,6 +36,7 @@ from grudge.op import (
     reference_inverse_mass_matrix,
     reference_derivative_matrices
 )
+from grudge.trace_pair import TracePair
 
 from meshmode.dof_array import DOFArray
 
@@ -391,9 +392,9 @@ def hybridized_sbp_operators(
         )
         e_mat = vf_mat @ p_mat
         q_skew_hybridized = np.asarray(
-            [0.5 * np.block([[q_mats[dim] - q_mats[dim].T, e_mat.T @ b_mats[dim]],
-                             [-b_mats[dim] @ e_mat, b_mats[dim]]])
-             for dim in range(vol_grp.dim)]
+            [0.5 * np.block([[q_mats[d] - q_mats[d].T, e_mat.T @ b_mats[d]],
+                             [-b_mats[d] @ e_mat, b_mats[d]]])
+             for d in range(vol_grp.dim)]
         )
         return actx.freeze(actx.from_numpy(q_skew_hybridized))
 
@@ -552,3 +553,28 @@ def sbp_lift_operator(dcoll: DiscretizationCollection, *args):
         raise TypeError("invalid number of arguments")
 
     return _apply_sbp_lift_operator(dcoll, dd, vec)
+
+
+def local_interior_trace_pair(
+    dcoll: DiscretizationCollection, dd, vec) -> TracePair:
+    r"""Return a :class:`TracePair` for the interior faces of
+    *dcoll* with a discretization tag specified by *discr_tag*.
+    This does not include interior faces on different MPI ranks.
+
+    :arg vec: a :class:`~meshmode.dof_array.DOFArray` or object array of
+        :class:`~meshmode.dof_array.DOFArray`\ s.
+    :returns: a :class:`TracePair` object.
+    """
+
+    import ipdb; ipdb.set_trace()
+
+    def get_opposite_face(el):
+        if isinstance(el, Number):
+            return el
+        else:
+            return dcoll.opposite_face_connection()(el)
+
+    e = obj_array_vectorize(get_opposite_face, i)
+    import ipdb; ipdb.set_trace()
+
+    return TracePair(dd.with_dtag("int_faces"), interior=i, exterior=e)

--- a/grudge/sbp_op.py
+++ b/grudge/sbp_op.py
@@ -26,9 +26,10 @@ THE SOFTWARE.
 from grudge.geometry.metrics import area_element
 from arraycontext import (
     ArrayContext,
-    make_loopy_program,
+    map_array_container,
     thaw
 )
+from functools import partial
 from grudge import discretization
 from meshmode.transform_metadata import FirstAxisIsElementsTag
 
@@ -65,9 +66,10 @@ def volume_quadrature_interpolation_matrix(
 
 
 def volume_quadrature_interpolation(dcoll: DiscretizationCollection, dq, vec):
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-            lambda el: volume_quadrature_interpolation(dcoll, dq, el), vec)
+    if not isinstance(vec, DOFArray):
+        return map_array_container(
+            partial(volume_quadrature_interpolation, dcoll, dq), vec
+        )
 
     actx = vec.array_context
     discr = dcoll.discr_from_dd("vol")
@@ -126,9 +128,10 @@ def surface_quadrature_interpolation_matrix(
 
 
 def quadrature_surface_interpolation(dcoll: DiscretizationCollection, df, vec):
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-            lambda el: quadrature_surface_interpolation(dcoll, df, el), vec)
+    if not isinstance(vec, DOFArray):
+        return map_array_container(
+            partial(quadrature_surface_interpolation, dcoll, df), vec
+        )
 
     actx = vec.array_context
     dtype = vec.entry_dtype
@@ -196,10 +199,11 @@ def volume_and_surface_quadrature_interpolation(
         dcoll: DiscretizationCollection, dq, df, vec):
     """todo.
     """
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-            lambda el: volume_and_surface_quadrature_interpolation(
-                dcoll, dq, df, el), vec)
+    if not isinstance(vec, DOFArray):
+        return map_array_container(
+            partial(volume_and_surface_quadrature_interpolation,
+                    dcoll, dq, df), vec
+        )
 
     actx = vec.array_context
     dtype = vec.entry_dtype
@@ -277,10 +281,11 @@ def volume_and_surface_quadrature_projection(
         dcoll: DiscretizationCollection, dq, df, vec):
     """todo.
     """
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-            lambda el: volume_and_surface_quadrature_projection(
-                dcoll, dq, df, el), vec)
+    if not isinstance(vec, DOFArray):
+        return map_array_container(
+            partial(volume_and_surface_quadrature_projection,
+                    dcoll, dq, df), vec
+        )
 
     actx = vec.array_context
     dtype = vec.entry_dtype
@@ -382,9 +387,10 @@ def volume_quadrature_l2_projection_matrix(
 
 
 def volume_quadrature_project(dcoll: DiscretizationCollection, dd_q, vec):
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-                lambda el: volume_quadrature_project(dcoll, dd_q, el), vec)
+    if not isinstance(vec, DOFArray):
+        return map_array_container(
+            partial(volume_quadrature_project, dcoll, dd_q), vec
+        )
 
     actx = vec.array_context
     discr = dcoll.discr_from_dd("vol")
@@ -521,10 +527,9 @@ def hybridized_sbp_operators(
 
 def _apply_inverse_sbp_mass_operator(
         dcoll: DiscretizationCollection, dd_quad, vec):
-    if isinstance(vec, np.ndarray):
-        return obj_array_vectorize(
-            lambda vi: _apply_inverse_sbp_mass_operator(dcoll, dd_quad, vi),
-            vec
+    if not isinstance(vec, DOFArray):
+        return map_array_container(
+            partial(_apply_inverse_sbp_mass_operator, dcoll, dd_quad), vec
         )
 
     actx = vec.array_context

--- a/grudge/sbp_op.py
+++ b/grudge/sbp_op.py
@@ -226,7 +226,6 @@ def hybridized_sbp_operators(
                              [-b_mats[dim] @ e_mat, b_mats[dim]]])
              for dim in range(vol_grp.dim)]
         )
-        import ipdb; ipdb.set_trace()
         return actx.freeze(actx.from_numpy(qhi))
 
     return get_hybridized_sbp_mats(face_element_group, vol_element_group)

--- a/grudge/sbp_op.py
+++ b/grudge/sbp_op.py
@@ -641,24 +641,19 @@ def volume_flux_differencing(
         )
 
     actx = vec.array_context
-
-    # flux_matrices = from_numpy(flux(_reshape_to_numpy((1, -1), vec),
-    #                                 _reshape_to_numpy((-1, 1), vec)), actx)
-    # import ipdb; ipdb.set_trace()
-
+    # FIXME: better way to do the reshaping here?
+    flux_matrices = from_numpy(flux(_reshape_to_numpy((1, -1), vec),
+                                    _reshape_to_numpy((-1, 1), vec)), actx)
     return volume_and_surface_quadrature_projection(
         dcoll,
         dq, df,
         _apply_skew_symmetric_hybrid_diff_operator(
             dcoll,
             dq, df,
-            # FIXME: better way to do the reshaping here?
-            # FIXME: need array container support
-            from_numpy(flux(_reshape_to_numpy((1, -1), vec),
-                            _reshape_to_numpy((-1, 1), vec)),
-                       actx)
+            flux_matrices
         )
     )
+
 
 def _apply_inverse_sbp_mass_operator(
         dcoll: DiscretizationCollection, dd_quad, vec):

--- a/grudge/sbp_op.py
+++ b/grudge/sbp_op.py
@@ -46,6 +46,26 @@ import grudge.dof_desc as dof_desc
 import numpy as np
 
 
+def volume_quadrature_interpolation_matrix(
+    actx: ArrayContext, base_element_group, quad_element_group):
+    """todo.
+    """
+    @keyed_memoize_in(
+        actx, volume_quadrature_interpolation_matrix,
+        lambda base_grp, quad_grp: (base_grp.discretization_key(),
+                                    quad_grp.discretization_key()))
+    def get_volume_vand(base_grp, quad_grp):
+        from modepy import vandermonde
+
+        basis = base_grp.basis_obj()
+        vdm_inv = np.linalg.inv(vandermonde(basis.functions,
+                                            base_grp.unit_nodes))
+        vdm_q = vandermonde(basis.functions, quad_grp.unit_nodes) @ vdm_inv
+        return actx.freeze(actx.from_numpy(vdm_q))
+
+    return get_volume_vand(base_element_group, quad_element_group)
+
+
 def quadrature_based_mass_matrix(
     actx: ArrayContext, base_element_group, quad_element_group):
     """todo.
@@ -55,12 +75,12 @@ def quadrature_based_mass_matrix(
         lambda base_grp, quad_grp: (base_grp.discretization_key(),
                                     quad_grp.discretization_key()))
     def get_ref_quad_mass_mat(base_grp, quad_grp):
-        from modepy import vandermonde
-
-        basis = base_grp.basis_obj()
-        vdm_inv = np.linalg.inv(vandermonde(basis.functions,
-                                            base_grp.unit_nodes))
-        vdm_q = vandermonde(basis.functions, quad_grp.unit_nodes) @ vdm_inv
+        vdm_q = actx.to_numpy(
+            thaw(
+                volume_quadrature_interpolation_matrix(actx, base_grp, quad_grp),
+                actx
+            )
+        )
         weights = np.diag(quad_grp.quadrature_rule().weights)
 
         return actx.freeze(actx.from_numpy(vdm_q.T @ weights @ vdm_q))
@@ -94,12 +114,12 @@ def quadrature_based_l2_projection_matrix(
         lambda base_grp, quad_grp: (base_grp.discretization_key(),
                                     quad_grp.discretization_key()))
     def get_ref_l2_proj_mat(base_grp, quad_grp):
-        from modepy import vandermonde
-
-        basis = base_grp.basis_obj()
-        vdm_inv = np.linalg.inv(vandermonde(basis.functions,
-                                            base_grp.unit_nodes))
-        vdm_q = vandermonde(basis.functions, quad_grp.unit_nodes) @ vdm_inv
+        vdm_q = actx.to_numpy(
+            thaw(
+                volume_quadrature_interpolation_matrix(actx, base_grp, quad_grp),
+                actx
+            )
+        )
         weights = np.diag(quad_grp.quadrature_rule().weights)
         inv_mass_mat = actx.to_numpy(
             thaw(quadrature_based_inverse_mass_matrix(
@@ -137,34 +157,29 @@ def quadrature_project(dcoll: DiscretizationCollection, dd_q, vec):
     )
 
 
-def quadrature_volume_interpolation(dcoll: DiscretizationCollection, vec):
+def quadrature_volume_interpolation(dcoll: DiscretizationCollection, dq, vec):
     if isinstance(vec, np.ndarray):
         return obj_array_vectorize(
-                lambda el: quadrature_volume_interpolation(dcoll, el), vec)
+            lambda el: quadrature_volume_interpolation(dcoll, dq, el), vec)
 
     actx = vec.array_context
     discr = dcoll.discr_from_dd("vol")
-
-    @keyed_memoize_in(
-        actx, quadrature_volume_interpolation,
-        lambda grp: grp.discretization_key())
-    def get_volume_vand(grp):
-        from modepy import vandermonde
-
-        quad_rule = grp.quadrature_rule()
-        vand = vandermonde(grp.basis_obj().functions, quad_rule.nodes)
-        return actx.freeze(actx.from_numpy(vand))
+    quad_discr = dcoll.discr_from_dd(dq)
 
     return DOFArray(
         actx,
         data=tuple(
             actx.einsum("ij,ej->ei",
-                        get_volume_vand(grp),
+                        volume_quadrature_interpolation_matrix(
+                            actx,
+                            base_element_group=bgrp,
+                            quad_element_group=qgrp
+                        ),
                         vec_i,
-                        arg_names=("Vq", "vec"),
+                        arg_names=("Vq_mat", "vec"),
                         tagged=(FirstAxisIsElementsTag(),))
 
-            for grp, vec_i in zip(discr.groups, vec)
+            for bgrp, qgrp, vec_i in zip(discr.groups, quad_discr.groups, vec)
         )
     )
 

--- a/grudge/sbp_op.py
+++ b/grudge/sbp_op.py
@@ -382,32 +382,18 @@ def boundary_integration_matrices(
         face_quad_weights = np.tile(face_quad_grp.weights, nfaces)
         nq_per_face = face_quad_grp.nunit_dofs
 
-        # FIXME: missing scaling factors here, need Jhat_f
-        # (Jacobian det of the change of coordinates to the reference face).
-        # from modepy import face_normal
-        # face_normals = [face_normal(face) for face in faces]
-        # e = np.ones(shape=(nq_per_face,))
-        # nrstj = np.array(
-        #     [np.concatenate([face_normal[idx]*e
-        #                      for face_normal in face_normals])
-        #         for idx in range(dim)]
-        # )
-        if dim == 1:
-            nrstj = np.array([[-1., 1.]])
-        elif dim == 2:
-            e = np.ones(shape=(nq_per_face,))
-            z = np.zeros(shape=(nq_per_face,))
-            nrstj = np.array([np.concatenate([z, -e, e]),
-                              np.concatenate([-e, z, e])])
-        elif dim == 3:
-            e = np.ones(shape=(nq_per_face,))
-            z = np.zeros(shape=(nq_per_face,))
-            nrstj = np.array([np.concatenate([z, z, -e, e]),
-                              np.concatenate([z, -e, z, e]),
-                              np.concatenate([-e, z, z, e])])
-        else:
-            raise ValueError(f"Bad value of dim: {dim}")
+        from modepy import face_normal
 
+        face_normals = [face_normal(face) for face in faces]
+
+        e = np.ones(shape=(nq_per_face,))
+        nrstj = np.array(
+            # nsrtJ = nhat * Jhatf, where nhat is the reference normal
+            # and Jhatf is the Jacobian det. of the transformation from
+            # the face of the reference element to the reference face.
+            [np.concatenate([np.sign(nhat[idx])*e for nhat in face_normals])
+             for idx in range(dim)]
+        )
         return actx.freeze(
             actx.from_numpy(
                 np.asarray(

--- a/test/test_entropy_stable.py
+++ b/test/test_entropy_stable.py
@@ -1,0 +1,140 @@
+__copyright__ = "Copyright (C) 2021 University of Illinois Board of Trustees"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+import numpy as np
+
+from grudge import DiscretizationCollection
+from grudge.dof_desc import DOFDesc, DISCR_TAG_BASE, DISCR_TAG_QUAD
+import grudge.sbp_op as sbp_op
+
+import pytest
+
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
+
+from pytools.obj_array import make_obj_array
+
+from arraycontext.container.traversal import thaw
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("order", [2, 3, 4])
+def test_entropy_projected_variables(actx_factory, order):
+
+    def simple_smooth_function(actx, dcoll, t=0, gamma=1.4, dd=None):
+        _beta = 5
+        _center = np.zeros(shape=(dim,))
+        _velocity = np.zeros(shape=(dim,))
+
+        vortex_loc = _center + t * _velocity
+
+        # Coordinates relative to vortex center
+        nodes = thaw(dcoll.nodes(dd), actx)
+        x_rel = nodes[0] - vortex_loc[0]
+        y_rel = nodes[1] - vortex_loc[1]
+ 
+        r = actx.np.sqrt(x_rel ** 2 + y_rel ** 2)
+        expterm = _beta * actx.np.exp(1 - r ** 2)
+        u = _velocity[0] - expterm * y_rel / (2 * np.pi)
+        v = _velocity[1] + expterm * x_rel / (2 * np.pi)
+        velocity = make_obj_array([u, v])
+        mass = (1 - (gamma - 1) / (16 * gamma * np.pi ** 2)
+                * expterm ** 2) ** (1 / (gamma - 1))
+        momentum = mass * velocity
+        p = mass ** gamma
+
+        energy = p / (gamma - 1) + mass / 2 * (u ** 2 + v ** 2)
+
+        result = np.empty((2+dim,), dtype=object)
+        result[0] = mass
+        result[1] = energy
+        result[2:dim+2] = momentum
+
+        return result
+
+    actx = actx_factory()
+
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+
+    dim = 2
+    nel_1d = 5
+    box_ll = -5.0
+    box_ur = 5.0
+    mesh = generate_regular_rect_mesh(
+        a=(box_ll,)*dim,
+        b=(box_ur,)*dim,
+        nelements_per_axis=(nel_1d,)*dim)
+
+    from meshmode.discretization.poly_element import \
+        default_simplex_group_factory, QuadratureSimplexGroupFactory
+
+    dcoll = DiscretizationCollection(
+        actx, mesh,
+        discr_tag_to_group_factory={
+            DISCR_TAG_BASE: default_simplex_group_factory(dim, order),
+            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order)
+        }
+    )
+    state = simple_smooth_function(actx, dcoll)
+    ddq = DOFDesc("vol", DISCR_TAG_QUAD)
+
+    from grudge.models.euler import \
+        conservative_to_entropy_vars, entropy_to_conservative_vars
+
+    entropy_vars = conservative_to_entropy_vars(dcoll, state)
+    convserved_vars = entropy_to_conservative_vars(dcoll, entropy_vars)
+
+    from meshmode.dof_array import flat_norm
+
+    assert bool(flat_norm(convserved_vars - state, 2) < 1e-13)
+
+    # # Compute uq = Vq * u
+    # uq = sbp_op.quadrature_volume_interpolation(dcoll, ddq, state)
+    # # Compute the entropy variables from state data: vq = v(uq)
+    # vq = conservative_to_entropy_vars(dcoll, uq)
+    # # Project the entropy variables to get modal coefficients
+    # # v = Pq * vq
+    # v = sbp_op.quadrature_project(dcoll, ddq, vq)
+    # # Interpolate coefficients to quadrature grid:
+    # # vtildeq = Vq * v
+    # vtildeq = sbp_op.quadrature_volume_interpolation(dcoll, ddq, v)
+    # # Construct the "auxiliary conservative variables" using
+    # # the projected entropy variables:
+    # # utildeq = q(vtildeq)
+    # utildeq = entropy_to_conservative_vars(dcoll, vtildeq)
+
+
+# You can test individual routines by typing
+# $ python test_grudge.py 'test_routine()'
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        pytest.main([__file__])

--- a/test/test_sbp_op.py
+++ b/test/test_sbp_op.py
@@ -131,7 +131,7 @@ def test_reference_element_sbp_operators(actx_factory, dim, order):
             )
         )
         b_mats = actx.to_numpy(
-            thaw(sbp_op.boundary_matrices(
+            thaw(sbp_op.boundary_integration_matrices(
                 actx, vgrp, qfgrp), actx)
         )
         q_mats = np.asarray(

--- a/test/test_sbp_op.py
+++ b/test/test_sbp_op.py
@@ -1,0 +1,130 @@
+__copyright__ = "Copyright (C) 2021 University of Illinois Board of Trustees"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+import numpy as np
+
+import meshmode.mesh.generation as mgen
+
+from pytools.obj_array import make_obj_array
+
+from grudge import op, DiscretizationCollection
+from grudge.dof_desc import DOFDesc
+import grudge.sbp_op as sbp_op
+
+import pytest
+
+from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from arraycontext import pytest_generate_tests_for_array_contexts
+pytest_generate_tests = pytest_generate_tests_for_array_contexts(
+        [PytestPyOpenCLArrayContextFactory])
+
+from arraycontext.container.traversal import thaw
+
+from meshmode.dof_array import DOFArray, flat_norm
+from meshmode.transform_metadata import FirstAxisIsElementsTag
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+@pytest.mark.parametrize("order", [2, 3])
+def test_skew_hybridized_constant_preserving(actx_factory, dim, order):
+    actx = actx_factory()
+
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+
+    nel_1d = 5
+    box_ll = -5.0
+    box_ur = 5.0
+    mesh = generate_regular_rect_mesh(
+        a=(box_ll,)*dim,
+        b=(box_ur,)*dim,
+        nelements_per_axis=(nel_1d,)*dim)
+
+    from grudge import DiscretizationCollection
+    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
+    from meshmode.discretization.poly_element import \
+        default_simplex_group_factory, QuadratureSimplexGroupFactory
+
+    dcoll = DiscretizationCollection(
+        actx, mesh,
+        discr_tag_to_group_factory={
+            DISCR_TAG_BASE: default_simplex_group_factory(dim, order),
+            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order)
+        }
+    )
+
+    dd_q = DOFDesc("vol", DISCR_TAG_QUAD)
+    dd_f = DOFDesc("all_faces", DISCR_TAG_QUAD)
+
+    volm_discr = dcoll.discr_from_dd("vol")
+    face_discr = dcoll.discr_from_dd("all_faces")
+    quad_discr = dcoll.discr_from_dd(dd_q)
+    quad_face_discr = dcoll.discr_from_dd(dd_f)
+
+    dtype = volm_discr.zeros(actx).entry_dtype
+
+    q1 = DOFArray(
+        actx,
+        data=tuple(
+            actx.einsum("dij,ej->ei",
+                        sbp_op.hybridized_sbp_operators(
+                            actx, fgrp, qfgrp,
+                            vgrp, qgrp, dtype
+                        ),
+                        actx.from_numpy(
+                            np.ones(
+                                (vgrp.nelements,
+                                 (qgrp.nunit_dofs
+                                  + (qgrp.mesh_el_group.nfaces \
+                                      * qfgrp.nunit_dofs))
+                                )
+                            )
+                        ),
+                        arg_names=("Q_mat", "one"),
+                        tagged=(FirstAxisIsElementsTag(),))
+
+            for vgrp, fgrp, qgrp, qfgrp in zip(
+                volm_discr.groups,
+                face_discr.groups,
+                quad_discr.groups,
+                quad_face_discr.groups)
+        )
+    )
+
+    # ugly hack to get around cl.Array(float)...
+    hopefully_zero = flat_norm(q1)
+    assert bool(hopefully_zero < 1e-12)
+
+
+# You can test individual routines by typing
+# $ python test_grudge.py 'test_routine()'
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        pytest.main([__file__])


### PR DESCRIPTION
Replaces https://github.com/inducer/grudge/pull/157

This PR implements flux differencing (currently using just numpy broadcasting) and adds summation-by-parts (SBP) DG operators via the new module `grudge.sbp_op`. Uses https://github.com/inducer/grudge/pull/154 as its base because of the array container support

An inviscid (Euler) model using entropy-stable DG (flux differencing + SBP ops) has been written up in `grudge.models.euler`. The specific DG formulation is the skew-symmetric form as presented by [Jesse Chan (2019)](https://arxiv.org/abs/1902.01828)

Further items that need to be addressed:

- [ ] Use array broadcasting provided by `actx`

- [ ] Add inviscid wall BCs