### PR TITLE
Reimplement `norm()` without recursion

### DIFF
--- a/grudge/op.py
+++ b/grudge/op.py
@@ -50,8 +50,6 @@ THE SOFTWARE.
 """
 
 
-from numbers import Number
-
 from arraycontext import ArrayContext
 from meshmode.transform_metadata import FirstAxisIsElementsTag
 
@@ -519,9 +517,7 @@ def reference_mass_matrix(actx: ArrayContext, out_element_group, in_element_grou
 
 def _apply_mass_operator(
         dcoll: DiscretizationCollection, dd_out, dd_in, vec):
-    if isinstance(vec, Number):
-        return vec
-    elif isinstance(vec, np.ndarray):
+    if isinstance(vec, np.ndarray):
         return obj_array_vectorize(
             lambda vi: _apply_mass_operator(dcoll,
                                             dd_out,

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -50,6 +50,8 @@ THE SOFTWARE.
 """
 
 
+from numbers import Number
+
 from arraycontext import ArrayContext
 from meshmode.transform_metadata import FirstAxisIsElementsTag
 
@@ -517,7 +519,9 @@ def reference_mass_matrix(actx: ArrayContext, out_element_group, in_element_grou
 
 def _apply_mass_operator(
         dcoll: DiscretizationCollection, dd_out, dd_in, vec):
-    if isinstance(vec, np.ndarray):
+    if isinstance(vec, Number):
+        return vec
+    elif isinstance(vec, np.ndarray):
         return obj_array_vectorize(
             lambda vi: _apply_mass_operator(dcoll,
                                             dd_out,

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -57,7 +57,6 @@ THE SOFTWARE.
 """
 
 
-from numbers import Number
 from functools import reduce
 
 from arraycontext import make_loopy_program
@@ -95,22 +94,18 @@ def norm(dcoll: DiscretizationCollection, vec, p, dd=None) -> float:
     from arraycontext import get_container_context_recursively
     actx = get_container_context_recursively(vec)
 
-    if actx is not None:
-        _np = actx.np
-    else:
-        _np = np
-
     dd = dof_desc.as_dofdesc(dd)
 
     if p == 2:
         from grudge.op import _apply_mass_operator
-        return _np.sqrt(
-            _np.abs(
+        return actx.np.sqrt(
+            actx.np.abs(
                 nodal_sum(
                     dcoll, dd,
-                    _np.conjugate(vec) * _apply_mass_operator(dcoll, dd, dd, vec))))
+                    actx.np.conjugate(vec)
+                    * _apply_mass_operator(dcoll, dd, dd, vec))))
     elif p == np.inf:
-        return nodal_max(dcoll, dd, _np.abs(vec))
+        return nodal_max(dcoll, dd, actx.np.abs(vec))
     else:
         raise ValueError("unsupported norm order")
 

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -75,23 +75,6 @@ import grudge.dof_desc as dof_desc
 
 # {{{ Nodal reductions
 
-def _norm(dcoll: DiscretizationCollection, vec, p, dd):
-    if isinstance(vec, Number):
-        return np.fabs(vec)
-    if p == 2:
-        from grudge.op import _apply_mass_operator
-        return abs(
-            nodal_sum(
-                dcoll,
-                dd,
-                vec.conj() * _apply_mass_operator(dcoll, dd, dd, vec))
-            )**(1/2)
-    elif p == np.inf:
-        return nodal_max(dcoll, dd, abs(vec))
-    else:
-        raise NotImplementedError("Unsupported value of p")
-
-
 def norm(dcoll: DiscretizationCollection, vec, p, dd=None) -> float:
     r"""Return the vector p-norm of a function represented
     by its vector of degrees of freedom *vec*.
@@ -109,23 +92,27 @@ def norm(dcoll: DiscretizationCollection, vec, p, dd=None) -> float:
     if dd is None:
         dd = dof_desc.DD_VOLUME
 
+    from arraycontext import get_container_context_recursively
+    actx = get_container_context_recursively(vec)
+
+    if actx is not None:
+        _np = actx.np
+    else:
+        _np = np
+
     dd = dof_desc.as_dofdesc(dd)
 
-    if isinstance(vec, np.ndarray):
-        if p == 2:
-            return sum(
-                norm(dcoll, vec[idx], p, dd=dd)**2
-                for idx in np.ndindex(vec.shape)
-            )**0.5
-        elif p == np.inf:
-            return max(
-                norm(dcoll, vec[idx], np.inf, dd=dd)
-                for idx in np.ndindex(vec.shape)
-            )
-        else:
-            raise ValueError("unsupported norm order")
-
-    return _norm(dcoll, vec, p, dd)
+    if p == 2:
+        from grudge.op import _apply_mass_operator
+        return _np.sqrt(
+            _np.abs(
+                nodal_sum(
+                    dcoll, dd,
+                    _np.conjugate(vec) * _apply_mass_operator(dcoll, dd, dd, vec))))
+    elif p == np.inf:
+        return nodal_max(dcoll, dd, _np.abs(vec))
+    else:
+        raise ValueError("unsupported norm order")
 
 
 def nodal_sum(dcoll: DiscretizationCollection, dd, vec) -> float:

--- a/test/test_grudge.py
+++ b/test/test_grudge.py
@@ -36,7 +36,7 @@ from arraycontext.container.traversal import thaw
 from meshmode.dof_array import flat_norm
 import meshmode.mesh.generation as mgen
 
-from pytools.obj_array import flat_obj_array, make_obj_array
+from pytools.obj_array import flat_obj_array
 
 from grudge import DiscretizationCollection
 
@@ -1020,6 +1020,27 @@ def test_bessel(actx_factory):
 
 
 @pytest.mark.parametrize("p", [2, np.inf])
+def test_norm_real(actx_factory, p):
+    actx = actx_factory()
+
+    dim = 2
+    mesh = mgen.generate_regular_rect_mesh(
+            a=(0,)*dim, b=(1,)*dim,
+            nelements_per_axis=(8,)*dim, order=1)
+    dcoll = DiscretizationCollection(actx, mesh, order=4)
+    nodes = thaw(dcoll.nodes(), actx)
+
+    norm = op.norm(dcoll, nodes[0], p)
+    if p == 2:
+        ref_norm = (1/3)**0.5
+    elif p == np.inf:
+        ref_norm = 1
+
+    logger.info("norm: %.5e %.5e", norm, ref_norm)
+    assert abs(norm-ref_norm) / abs(ref_norm) < 1e-13
+
+
+@pytest.mark.parametrize("p", [2, np.inf])
 def test_norm_complex(actx_factory, p):
     actx = actx_factory()
 
@@ -1028,52 +1049,38 @@ def test_norm_complex(actx_factory, p):
             a=(0,)*dim, b=(1,)*dim,
             nelements_per_axis=(8,)*dim, order=1)
     dcoll = DiscretizationCollection(actx, mesh, order=4)
-
     nodes = thaw(dcoll.nodes(), actx)
-    f = nodes[0] + 1j * nodes[0]
 
-    norm = op.norm(dcoll, f, p)
+    norm = op.norm(dcoll, (1 + 1j)*nodes[0], p)
     if p == 2:
-        ref_norm = ((1/3)*dim)**0.5
+        ref_norm = (2/3)**0.5
     elif p == np.inf:
         ref_norm = 2**0.5
 
+    logger.info("norm: %.5e %.5e", norm, ref_norm)
     assert abs(norm-ref_norm) / abs(ref_norm) < 1e-13
 
 
 @pytest.mark.parametrize("p", [2, np.inf])
 def test_norm_obj_array(actx_factory, p):
-    """Test :func:`grudge.op.norm` for object arrays."""
-
     actx = actx_factory()
 
     dim = 2
     mesh = mgen.generate_regular_rect_mesh(
-            a=(-0.5,)*dim, b=(0.5,)*dim,
+            a=(0,)*dim, b=(1,)*dim,
             nelements_per_axis=(8,)*dim, order=1)
     dcoll = DiscretizationCollection(actx, mesh, order=4)
+    nodes = thaw(dcoll.nodes(), actx)
 
-    w = make_obj_array([1.0, 2.0, 3.0])[:dim]
+    norm = op.norm(dcoll, nodes, p)
 
-    # {{ scalar
+    if p == 2:
+        ref_norm = (dim/3)**0.5
+    elif p == np.inf:
+        ref_norm = 1
 
-    norm = op.norm(dcoll, w[0], p)
-
-    norm_exact = w[0]
-    logger.info("norm: %.5e %.5e", norm, norm_exact)
-    assert abs(norm - norm_exact) < 1.0e-14
-
-    # }}}
-
-    # {{{ vector
-
-    norm = op.norm(dcoll, w, p)
-
-    norm_exact = np.sqrt(np.sum(w**2)) if p == 2 else np.max(w)
-    logger.info("norm: %.5e %.5e", norm, norm_exact)
-    assert abs(norm - norm_exact) < 1.0e-14
-
-    # }}}
+    logger.info("norm: %.5e %.5e", norm, ref_norm)
+    assert abs(norm-ref_norm) / abs(ref_norm) < 1e-14
 
 
 def test_empty_boundary(actx_factory):


### PR DESCRIPTION
~~:warning: Depends on inducer/arraycontext#112 (for correct `np.ndarray` handling in `_map_array_container_impl`). :warning:~~ (Merged.)

Avoids some unnecessary squaring/`sqrt`ing, ~~and also handles the "object array of scalars" case without resorting to a duplicate implementation ([previous discussion](https://github.com/inducer/grudge/pull/154#discussion_r733164776)).~~

~~Not entirely sure whether what I'm doing for the scalar case in `_apply_mass_operator` is legit, but it at least replicates the previous behavior.~~ (Ended up removing support for norms of scalars.)