### PR TITLE
Do not deprecate rank-local interior trace pairs

### DIFF
--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -16,8 +16,8 @@ Boundary trace functions
 Interior and cross-rank trace functions
 ---------------------------------------
 
-.. autofunction:: interior_trace_pair
 .. autofunction:: interior_trace_pairs
+.. autofunction:: local_interior_trace_pair
 .. autofunction:: cross_rank_trace_pairs
 """
 
@@ -215,7 +215,7 @@ def bv_trace_pair(
 
 # {{{ Interior trace pairs
 
-def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
+def local_interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
     r"""Return a :class:`TracePair` for the interior faces of
     *dcoll* with a discretization tag specified by *discr_tag*.
     This does not include interior faces on different MPI ranks.
@@ -247,21 +247,31 @@ def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
     return TracePair("int_faces", interior=i, exterior=e)
 
 
+def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
+    from warnings import warn
+    warn("`grudge.op.interior_trace_pair` is deprecated and will be dropped "
+         "in version 2022.x. Use `local_interior_trace_pair` "
+         "instead, or `interior_trace_pairs` which also includes contributions "
+         "from different MPI ranks.",
+         DeprecationWarning, stacklevel=2)
+    return local_interior_trace_pair(dcoll, vec)
+
+
 def interior_trace_pairs(dcoll: DiscretizationCollection, vec) -> list:
     r"""Return a :class:`list` of :class:`TracePair` objects
     defined on the interior faces of *dcoll* and any faces connected to a
     parallel boundary.
 
-    Note that :func:`interior_trace_pair` provides the rank-local contributions
-    if those are needed in isolation.
+    Note that :func:`local_interior_trace_pair` provides the rank-local contributions
+    if those are needed in isolation. Similarly, :func:`cross_rank_trace_pairs`
+    provides only the trace pairs defined on cross-rank boundaries.
 
     :arg vec: a :class:`~meshmode.dof_array.DOFArray` or object array of
         :class:`~meshmode.dof_array.DOFArray`\ s.
     :returns: a :class:`list` of :class:`TracePair` objects.
     """
     return (
-        [interior_trace_pair(dcoll, vec)]
-        + cross_rank_trace_pairs(dcoll, vec)
+        [local_interior_trace_pair(dcoll, vec)] + cross_rank_trace_pairs(dcoll, vec)
     )
 
 # }}}

--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -220,6 +220,14 @@ def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
     *dcoll* with a discretization tag specified by *discr_tag*.
     This does not include interior faces on different MPI ranks.
 
+    For certain applications, it may be useful to distinguish between
+    rank-local and cross-rank trace pairs. For example, avoiding unnecessary
+    communication of derived quantities (i.e. temperature) on partition
+    boundaries by computing them directly. Having the ability for
+    user applications to distinguish between rank-local and cross-rank
+    contributions can also help enable overlapping communication with
+    computation.
+
     :arg vec: a :class:`~meshmode.dof_array.DOFArray` or object array of
         :class:`~meshmode.dof_array.DOFArray`\ s.
     :returns: a :class:`TracePair` object.
@@ -243,6 +251,9 @@ def interior_trace_pairs(dcoll: DiscretizationCollection, vec) -> list:
     r"""Return a :class:`list` of :class:`TracePair` objects
     defined on the interior faces of *dcoll* and any faces connected to a
     parallel boundary.
+
+    Note that :func:`interior_trace_pair` provides the rank-local contributions
+    if those are needed in isolation.
 
     :arg vec: a :class:`~meshmode.dof_array.DOFArray` or object array of
         :class:`~meshmode.dof_array.DOFArray`\ s.

--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -16,6 +16,7 @@ Boundary trace functions
 Interior and cross-rank trace functions
 ---------------------------------------
 
+.. autofunction:: interior_trace_pair
 .. autofunction:: interior_trace_pairs
 .. autofunction:: cross_rank_trace_pairs
 """
@@ -214,7 +215,7 @@ def bv_trace_pair(
 
 # {{{ Interior trace pairs
 
-def _interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
+def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
     r"""Return a :class:`TracePair` for the interior faces of
     *dcoll* with a discretization tag specified by *discr_tag*.
     This does not include interior faces on different MPI ranks.
@@ -248,18 +249,9 @@ def interior_trace_pairs(dcoll: DiscretizationCollection, vec) -> list:
     :returns: a :class:`list` of :class:`TracePair` objects.
     """
     return (
-        [_interior_trace_pair(dcoll, vec)]
+        [interior_trace_pair(dcoll, vec)]
         + cross_rank_trace_pairs(dcoll, vec)
     )
-
-
-def interior_trace_pair(dcoll: DiscretizationCollection, vec) -> TracePair:
-    from warnings import warn
-    warn("`grudge.op.interior_trace_pair` is deprecated and will be dropped "
-         "in version 2022.x. Use `grudge.trace_pair.interior_trace_pairs` "
-         "instead, which includes contributions from different MPI ranks.",
-         DeprecationWarning, stacklevel=2)
-    return _interior_trace_pair(dcoll, vec)
 
 # }}}
 


### PR DESCRIPTION
This simple PR removes the deprecation warning for `interior_trace_pair`, since there are legitimate reasons (cc. @MTCam and the Navier-Stokes operator) you'd want to handle the rank-local interior trace pairs independently from the cross-rank pairs.

Also we may want to try some latency hiding in lazy mode soon, so we probably want to treat all rank-local surface + volume terms as a unit when attempting to overlap communication with computation.