### PR TITLE
Add missing map_common_subexpression_uncached to DOFDescInferenceMapper

### DIFF
--- a/grudge/symbolic/dofdesc_inference.py
+++ b/grudge/symbolic/dofdesc_inference.py
@@ -193,6 +193,9 @@ class DOFDescInferenceMapper(RecursiveMapper, CSECachingMapperMixin):
                 self.function_registry[expr.function.name]
                 .get_result_dofdesc(arg_dds))
 
+    def map_common_subexpression_uncached(self, expr):
+        return self.rec(expr.child)
+
     # }}}
 
     # {{{ instruction mappings


### PR DESCRIPTION
Needed for https://github.com/inducer/pymbolic/pull/75.