### PR TITLE
Force a single-value per element for elementwise reductions

### DIFF
--- a/grudge/dt_utils.py
+++ b/grudge/dt_utils.py
@@ -277,46 +277,33 @@ def dt_geometric_factors(
         )
     )
 
-    if actx.supports_nonscalar_broadcasting:
-        # Sum the areas of each face to get the total surface area
-        surface_areas = DOFArray(
-            actx,
-            data=tuple(
-                actx.einsum(
-                    "fej->e",
-                    face_ae_i.reshape(
-                        vgrp.mesh_el_group.nfaces,
-                        vgrp.nelements,
-                        1
-                    ),
-                    tagged=(FirstAxisIsElementsTag(),))
+    # Sum the areas of each face to get the total surface area
+    surface_areas = DOFArray(
+        actx,
+        data=tuple(
+            actx.einsum(
+                "fej->e",
+                face_ae_i.reshape(
+                    vgrp.mesh_el_group.nfaces,
+                    vgrp.nelements,
+                    -1
+                ),
+                tagged=(FirstAxisIsElementsTag(),)) / (
+                    # NOTE: Whenever the array context can't perform nonscalar
+                    # broadcasting, elementwise reductions
+                    # (like `elementwise_integral`) repeat the scalar value of
+                    # the reduction at each degree of freedom. To get a single
+                    # value for the total surface area of a cell,
+                    # we sum over all nodes and average.
+                    1 if actx.supports_nonscalar_broadcasting
+                    else afgrp.nunit_dofs
+                )
 
-                for vgrp, face_ae_i in zip(volm_discr.groups, surface_areas)
-            )
+            for vgrp, afgrp, face_ae_i in zip(volm_discr.groups,
+                                              face_discr.groups,
+                                              surface_areas)
         )
-    else:
-        # Whenever the array context can't perform nonscalar broadcasting,
-        # elementwise reductions (like `elementwise_integral`) repeat the
-        # scalar value of the reduction at each degree of freedom.
-        # To get a single value for the total surface area of a cell,
-        # we take the sum over the averaged face areas on each face.
-        surface_areas = DOFArray(
-            actx,
-            data=tuple(
-                actx.einsum(
-                    "fej->e",
-                    face_ae_i.reshape(
-                        vgrp.mesh_el_group.nfaces,
-                        vgrp.nelements,
-                        afgrp.nunit_dofs
-                    ),
-                    tagged=(FirstAxisIsElementsTag(),)) / afgrp.nunit_dofs
-
-                for vgrp, afgrp, face_ae_i in zip(volm_discr.groups,
-                                                  face_discr.groups,
-                                                  surface_areas)
-            )
-        )
+    )
 
     return freeze(DOFArray(
         actx,

--- a/grudge/dt_utils.py
+++ b/grudge/dt_utils.py
@@ -271,43 +271,50 @@ def dt_geometric_factors(
     dd_face = DOFDesc("all_faces", dd.discretization_tag)
     face_discr = dcoll.discr_from_dd(dd_face)
 
-    # To get a single value for the total surface area of a cell, we
-    # take the sum over the averaged face areas on each face.
-    # NOTE: The face areas are the *same* at each face nodal location.
-    # This assumes there are the *same* number of face nodes on each face.
-    surface_areas = abs(
+    # Compute areas of each face
+    face_areas = abs(
         op.elementwise_integral(
             dcoll, dd_face, face_discr.zeros(actx) + 1.0
         )
     )
-    surface_areas = DOFArray(
-        actx,
-        data=tuple(
-            # NOTE: Whenever the array context can't perform nonscalar
-            # broadcasting, elementwise reductions
-            # (like `elementwise_integral`) repeat the *same* scalar value of
-            # the reduction at each degree of freedom. To get a single
-            # value for the face area (per face),
-            # we simply average over the nodes, which gives the desired result.
-            actx.einsum(
-                "fej->e",
-                face_ae_i.reshape(
-                    vgrp.mesh_el_group.nfaces,
-                    vgrp.nelements,
-                    -1
-                ),
-                tagged=(FirstAxisIsElementsTag(),)) / (
-                    # NOTE: This assumes there are the *same* number of
-                    # face nodes on each face.
-                    1 if actx.supports_nonscalar_broadcasting
-                    else afgrp.nunit_dofs
-                )
 
-            for vgrp, afgrp, face_ae_i in zip(volm_discr.groups,
-                                              face_discr.groups,
-                                              surface_areas)
+    if actx.supports_nonscalar_broadcasting:
+        # Compute total surface area of an element by summing over the
+        # individual face areas
+        surface_areas = DOFArray(
+            actx,
+            data=tuple(
+                actx.einsum(
+                    "fej->e",
+                    face_ae_i.reshape(
+                        vgrp.mesh_el_group.nfaces, vgrp.nelements, -1),
+                    tagged=(FirstAxisIsElementsTag(),))
+
+                for vgrp, face_ae_i in zip(volm_discr.groups, face_areas)
+            )
         )
-    )
+    else:
+        surface_areas = DOFArray(
+            actx,
+            data=tuple(
+                # NOTE: Whenever the array context can't perform nonscalar
+                # broadcasting, elementwise reductions
+                # (like `elementwise_integral`) repeat the *same* scalar value of
+                # the reduction at each degree of freedom. To get a single
+                # value for the face area (per face),
+                # we simply average over the nodes, which gives the desired result.
+                actx.einsum(
+                    "fej->e",
+                    face_ae_i.reshape(
+                        vgrp.mesh_el_group.nfaces, vgrp.nelements, -1
+                    ) / afgrp.nunit_dofs,
+                    tagged=(FirstAxisIsElementsTag(),))
+
+                for vgrp, afgrp, face_ae_i in zip(volm_discr.groups,
+                                                face_discr.groups,
+                                                face_areas)
+            )
+        )
 
     return freeze(DOFArray(
         actx,

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -268,10 +268,16 @@ def integral(dcoll: DiscretizationCollection, dd, vec) -> "DeviceScalar":
 def _apply_elementwise_reduction(
         op_name: str, dcoll: DiscretizationCollection,
         *args) -> ArrayOrContainerT:
-    r"""Returns a vector of DOFs with all entries on each element set
-    to the reduction operation *op_name* over all degrees of freedom.
+    r"""Returns an array container whose entries contain
+    the elementwise reductions in each cell.
 
     May be called with ``(vec)`` or ``(dd, vec)``.
+
+    Note that for array contexts which support nonscalar broadcasting
+    (e.g. :class:`meshmode.array_context.PytatoPyOpenCLArrayContext`),
+    the size of each component vector will be of shape `(nelements, 1)`.
+    Otherwise, the scalar value of the reduction will be repeated for each
+    degree of freedom.
 
     :arg dd: a :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one.
         Defaults to the base volume discretization if not provided.
@@ -301,9 +307,7 @@ def _apply_elementwise_reduction(
         return DOFArray(
             actx,
             data=tuple(
-                actx.np.broadcast_to((getattr(actx.np, op_name)(vec_i, axis=1)
-                                      .reshape(-1, 1)),
-                                     vec_i.shape)
+                getattr(actx.np, op_name)(vec_i, axis=1).reshape(-1, 1)
                 for vec_i in vec
             )
         )

--- a/grudge/reductions.py
+++ b/grudge/reductions.py
@@ -275,7 +275,7 @@ def _apply_elementwise_reduction(
 
     Note that for array contexts which support nonscalar broadcasting
     (e.g. :class:`meshmode.array_context.PytatoPyOpenCLArrayContext`),
-    the size of each component vector will be of shape `(nelements, 1)`.
+    the size of each component vector will be of shape ``(nelements, 1)``.
     Otherwise, the scalar value of the reduction will be repeated for each
     degree of freedom.
 

--- a/test/test_dt_utils.py
+++ b/test/test_dt_utils.py
@@ -26,10 +26,14 @@ import numpy as np
 
 from arraycontext import thaw
 
-from grudge.array_context import PytestPyOpenCLArrayContextFactory
+from grudge.array_context import (
+    PytestPyOpenCLArrayContextFactory,
+    PytestPytatoPyOpenCLArrayContextFactory
+)
 from arraycontext import pytest_generate_tests_for_array_contexts
 pytest_generate_tests = pytest_generate_tests_for_array_contexts(
-        [PytestPyOpenCLArrayContextFactory])
+        [PytestPyOpenCLArrayContextFactory,
+         PytestPytatoPyOpenCLArrayContextFactory])
 
 from grudge import DiscretizationCollection
 


### PR DESCRIPTION
This PR fixes #184

The logic here is that it's safe to force the elementwise reductions to have a shape of `(nelem, 1)` by definition of a reduction in this context; no need to broadcast to a full DOFArray