### PR TITLE
Make the result of `dt_geometric_factors` in 1D consistent with other dimensions

### DIFF
--- a/grudge/dt_utils.py
+++ b/grudge/dt_utils.py
@@ -266,6 +266,7 @@ def dt_geometric_factors(
     )
 
     if dcoll.dim == 1:
+        # Inscribed "circle" radius is half the cell size
         return freeze(cell_vols/2)
 
     dd_face = DOFDesc("all_faces", dd.discretization_tag)

--- a/grudge/dt_utils.py
+++ b/grudge/dt_utils.py
@@ -266,7 +266,7 @@ def dt_geometric_factors(
     )
 
     if dcoll.dim == 1:
-        return freeze(cell_vols)
+        return freeze(cell_vols/2)
 
     dd_face = DOFDesc("all_faces", dd.discretization_tag)
     face_discr = dcoll.discr_from_dd(dd_face)


### PR DESCRIPTION
I noticed `characteristic_lengthscales` was returning larger values than expected for 1D (e.g., returning `2` for a cell of length `1` with 1st order), and this appears to be the culprit. `dt_geometric_factors` returns inscribed circle radii for `dim > 1`, but it returns diameters for `dim == 1`.