### PR TITLE
Get_attr from world

### DIFF
--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -505,7 +505,7 @@ def cross_rank_trace_pairs(
                 # - https://github.com/illinois-ceesd/mirgecom/issues/617#issuecomment-1057082716  # noqa
                 # - https://github.com/inducer/grudge/pull/222
                 from mpi4py import MPI
-                tag_ub = actx.mpi_communicator.Get_attr(MPI.TAG_UB)
+                tag_ub = MPI.COMM_WORLD.Get_attr(MPI.TAG_UB)
                 key_builder = _TagKeyBuilder()
                 digest = key_builder(comm_tag)
                 num_tag = sum(ord(ch) << i for i, ch in enumerate(digest)) % tag_ub


### PR DESCRIPTION
It is OK to use COMM_WORLD here, and this continues to work even for array contexts that don't have the mpi_communicator attribute.  This fixes many failing tests in MIRGE-Com.