### PR TITLE
Oversubscribe MPI example run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
                 python euler/acoustic_pulse.py --lazy
                 python euler/vortex.py --oi --lazy
 
-                mpirun -n 2 python wave/wave-op-mpi.py --lazy
+                mpiexec -np 2 --oversubscribe python wave/wave-op-mpi.py --lazy
 
     docs:
         name: Documentation


### PR DESCRIPTION
https://github.com/inducer/grudge/runs/5400939277?check_suite_focus=true showed this failure:

```
--------------------------------------------------------------------------
There are not enough slots available in the system to satisfy the 2
slots that were requested by the application:

  python

Either request fewer slots for your application, or make more slots
available for use.

A "slot" is the Open MPI term for an allocatable unit where we can
launch a process.  The number of slots available are defined by the
environment in which Open MPI processes are run:

  1. Hostfile, via "slots=N" clauses (N defaults to number of
     processor cores if not provided)
  2. The --host command line parameter, via a ":N" suffix on the
     hostname (N defaults to 1 if not provided)
  3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
  4. If none of a hostfile, the --host command line parameter, or an
     RM is present, Open MPI defaults to the number of processor cores

In all the above cases, if you want Open MPI to default to the number
of hardware threads instead of the number of processor cores, use the
--use-hwthread-cpus option.

Alternatively, you can use the --oversubscribe option to ignore the
number of available slots when deciding the number of processes to
launch.
--------------------------------------------------------------------------
```

cc @matthiasdiener 