### PR TITLE
Add a helper to enable use of compiled LSRK45

### DIFF
--- a/test/test_grudge.py
+++ b/test/test_grudge.py
@@ -724,6 +724,8 @@ def test_convergence_advec(actx_factory, mesh_name, mesh_pars, op_type, flux_typ
         def rhs(t, u):
             return adv_operator.operator(t, u)
 
+        compiled_rhs = actx.compile(rhs)
+
         if dim == 3:
             final_time = 0.1
         else:
@@ -734,35 +736,35 @@ def test_convergence_advec(actx_factory, mesh_name, mesh_pars, op_type, flux_typ
         h_max = h_max_from_volume(dcoll, dim=dcoll.ambient_dim)
         dt = actx.to_numpy(dt_factor * h_max/order**2)
         nsteps = (final_time // dt) + 1
-        dt = final_time/nsteps + 1e-15
+        tol = 1e-14
+        dt = final_time/nsteps + tol
 
-        from grudge.shortcuts import set_up_rk4
-        dt_stepper = set_up_rk4("u", dt, u, rhs)
-
-        last_u = None
-
-        from grudge.shortcuts import make_visualizer
+        from grudge.shortcuts import make_visualizer, compiled_lsrk45_step
         vis = make_visualizer(dcoll)
 
         step = 0
+        t = 0
 
-        for event in dt_stepper.run(t_end=final_time):
-            if isinstance(event, dt_stepper.StateComputed):
-                step += 1
-                logger.debug("[%04d] t = %.5f", step, event.t)
+        while t < final_time - tol:
+            step += 1
+            logger.debug("[%04d] t = %.5f", step, t)
 
-                last_t = event.t
-                last_u = event.state_component
+            u = compiled_lsrk45_step(actx, u, t, dt, compiled_rhs)
 
-                if visualize:
-                    vis.write_vtk_file(
-                        "fld-%s-%04d.vtu" % (mesh_par, step),
-                        [("u", event.state_component)]
-                    )
+            if visualize:
+                vis.write_vtk_file(
+                    "fld-%s-%04d.vtu" % (mesh_par, step),
+                    [("u", u)]
+                )
+
+            t += dt
+
+            if t + dt >= final_time - tol:
+                dt = final_time-t
 
         error_l2 = op.norm(
             dcoll,
-            last_u - u_analytic(nodes, t=last_t),
+            u - u_analytic(nodes, t=t),
             2
         )
         logger.info("h_max %.5e error %.5e", actx.to_numpy(h_max), error_l2)


### PR DESCRIPTION
This seems to work, and it seems to help a fair bit for the wave operator. It's at 0.008s on my laptop. (Earlier measurements were 0.06s, but I forgot what those were.)

Draft because:
- [x] Needs https://github.com/inducer/pytato/pull/308
- [x] ~~Find a way to get rid of the extra `_cls_has_array_context_attr=True`.~~ Can't, currently. See discussion in https://github.com/inducer/arraycontext/pull/155.
- [x] Wait for https://github.com/inducer/arraycontext/pull/155 to make this easier to use.
- [x] Use this in a convergence test.

cc @MTCam 