### PR TITLE
 Add EqualityMapper to follow pymbolic

### DIFF
--- a/grudge/symbolic/operators.py
+++ b/grudge/symbolic/operators.py
@@ -139,6 +139,11 @@ class Operator(pymbolic.primitives.Expression):
     def make_stringifier(self, originating_stringifier=None):
         from grudge.symbolic.mappers import StringifyMapper
         return StringifyMapper()
+
+    def make_equality_mapper(self):
+        from grudge.symbolic.mappers import EqualityMapper
+        return EqualityMapper()
+
 # }}}
 
 

--- a/grudge/symbolic/primitives.py
+++ b/grudge/symbolic/primitives.py
@@ -42,6 +42,10 @@ class ExpressionBase(prim.Expression):
         from grudge.symbolic.mappers import StringifyMapper
         return StringifyMapper()
 
+    def make_equality_mapper(self):
+        from grudge.symbolic.mappers import EqualityMapper
+        return EqualityMapper()
+
 
 __doc__ = """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 numpy
 mpi4py
 git+https://github.com/inducer/pytools.git#egg=pytools
-git+https://github.com/inducer/pymbolic.git#egg=pymbolic
+git+https://github.com/alexfikl/pymbolic.git@equality-mapper#egg=pymbolic
 git+https://github.com/inducer/islpy.git#egg=islpy
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl
-git+https://github.com/inducer/loopy.git#egg=loopy
+git+https://github.com/alexfikl/loopy.git@equality-mapper#egg=loopy
 git+https://github.com/inducer/dagrt.git#egg=dagrt
 git+https://github.com/inducer/leap.git#egg=leap
 git+https://github.com/inducer/meshpy.git#egg=meshpy
@@ -14,7 +14,7 @@ git+https://github.com/inducer/meshmode.git#egg=meshmode
 git+https://github.com/inducer/pyvisfile.git#egg=pyvisfile
 git+https://github.com/inducer/pymetis.git#egg=pymetis
 git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle
-git+https://github.com/inducer/pytato.git#egg=pytato
+git+https://github.com/alexfikl/pytato.git@equality-mapper#egg=pytato
 
 # for test_wave_dt_estimate
 sympy

--- a/test/test_mpi_communication.py
+++ b/test/test_mpi_communication.py
@@ -100,6 +100,7 @@ def run_test_with_mpi_inner():
 
 # {{{ func_comparison
 
+@pytest.mark.mpi
 @pytest.mark.parametrize("actx_class", DISTRIBUTED_ACTXS)
 @pytest.mark.parametrize("num_ranks", [2])
 def test_func_comparison_mpi(actx_class, num_ranks):
@@ -177,6 +178,7 @@ def _test_func_comparison_mpi_communication_entrypoint(actx):
 
 # {{{ wave operator
 
+@pytest.mark.mpi
 @pytest.mark.parametrize("actx_class", DISTRIBUTED_ACTXS)
 @pytest.mark.parametrize("num_ranks", [2])
 def test_mpi_wave_op(actx_class, num_ranks):


### PR DESCRIPTION
See inducer/pymbolic#74.

This is only needed in the symbolic parts, which should be deprecated. A good time to rip them out completely?