### PR TITLE
Make `dt_geometric_factors` work with empty meshes

### DIFF
--- a/grudge/dt_utils.py
+++ b/grudge/dt_utils.py
@@ -288,7 +288,9 @@ def dt_geometric_factors(
                 actx.einsum(
                     "fej->e",
                     face_ae_i.reshape(
-                        vgrp.mesh_el_group.nfaces, vgrp.nelements, -1),
+                        vgrp.mesh_el_group.nfaces,
+                        vgrp.nelements,
+                        face_ae_i.shape[-1]),
                     tagged=(FirstAxisIsElementsTag(),))
 
                 for vgrp, face_ae_i in zip(volm_discr.groups, face_areas)
@@ -307,7 +309,9 @@ def dt_geometric_factors(
                 actx.einsum(
                     "fej->e",
                     face_ae_i.reshape(
-                        vgrp.mesh_el_group.nfaces, vgrp.nelements, -1
+                        vgrp.mesh_el_group.nfaces,
+                        vgrp.nelements,
+                        face_ae_i.shape[-1]
                     ) / afgrp.nunit_dofs,
                     tagged=(FirstAxisIsElementsTag(),))
 

--- a/grudge/op.py
+++ b/grudge/op.py
@@ -874,7 +874,7 @@ def _apply_face_mass_operator(dcoll: DiscretizationCollection, dd, vec):
                         surf_ae_i.reshape(
                                 vgrp.mesh_el_group.nfaces,
                                 vgrp.nelements,
-                                -1),
+                                surf_ae_i.shape[-1]),
                         vec_i.reshape(
                                 vgrp.mesh_el_group.nfaces,
                                 vgrp.nelements,

--- a/test/test_dt_utils.py
+++ b/test/test_dt_utils.py
@@ -85,6 +85,11 @@ def test_geometric_factors_regular_refinement(actx_factory, name):
     ratios = min_factors[:-1] / min_factors[1:]
     assert np.all(np.isclose(ratios, 2))
 
+    # Make sure it works with empty meshes
+    mesh = builder.get_mesh(0, builder.mesh_order)
+    dcoll = DiscretizationCollection(actx, mesh, order=builder.order)
+    factors = thaw(dt_geometric_factors(dcoll), actx)  # noqa: F841
+
 
 @pytest.mark.parametrize("name", ["interval", "box2d", "box3d"])
 def test_non_geometric_factors(actx_factory, name):


### PR DESCRIPTION
~~:warning: Depends on inducer/meshmode#330. :warning:~~ (Merged.)