### PR TITLE
Pass array containers to connection in `project()`

### DIFF
--- a/grudge/projection.py
+++ b/grudge/projection.py
@@ -32,15 +32,10 @@ THE SOFTWARE.
 """
 
 
-from functools import partial
-
-from arraycontext import map_array_container
 from arraycontext.container import ArrayOrContainerT
 
 from grudge.discretization import DiscretizationCollection
 from grudge.dof_desc import as_dofdesc
-
-from meshmode.dof_array import DOFArray
 
 from numbers import Number
 
@@ -63,10 +58,5 @@ def project(
 
     if isinstance(vec, Number) or src == tgt:
         return vec
-
-    if not isinstance(vec, DOFArray):
-        return map_array_container(
-            partial(project, dcoll, src, tgt), vec
-        )
 
     return dcoll.connection_from_dds(src, tgt)(vec)


### PR DESCRIPTION
Since array containers stay together longer, this may help with generating sensible names. It's also entirely unnecessary to pick containers apart at this stage.