### PR TITLE
Place asterisk before keyword arguments in MPIPytatoArrayContextBase

### DIFF
--- a/grudge/array_context.py
+++ b/grudge/array_context.py
@@ -381,7 +381,7 @@ class _DistributedCompiledFunction:
 
 class MPIPytatoArrayContextBase(MPIBasedArrayContext):
     def __init__(
-            self, mpi_communicator, queue, *, mpi_base_tag, allocator=None,
+            self, mpi_communicator, queue, mpi_base_tag, *, allocator=None,
             compile_trace_callback: Optional[Callable[[Any, str, Any], None]]
             = None) -> None:
         """


### PR DESCRIPTION
The asterisk placement causes an error when I try to run with lazy. Moving it to right before the keyword arguments seems to fix it.

```
Traceback (most recent call last):
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/site-packages/mpi4py/__main__.py", line 7, in <module>
    main()
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/site-packages/mpi4py/run.py", line 198, in main
    run_command_line(args)
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/site-packages/mpi4py/run.py", line 47, in run_command_line
    run_path(sys.argv[0], run_name='__main__')
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/runpy.py", line 268, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/ccs/home/njchris/miniconda3/envs/dev-spock/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "isolator.py", line 1564, in <module>
    main(restart_filename=restart_filename, user_input_file=input_file,
  File "/autofs/nccs-svm1_home1/njchris/Workspace/mirgecom-upstream/mirgecom/mpi.py", line 157, in wrapped_func
    func(*args, **kwargs)
  File "isolator.py", line 766, in main
    actx = actx_class(comm, queue, mpi_base_tag,
TypeError: __init__() takes 3 positional arguments but 4 positional arguments (and 1 keyword-only argument) were given
Default casename isolator
Using user input from file: run_params.yaml
Running isolator.py

    def __init__(
            self, mpi_communicator, queue, *, mpi_base_tag, allocator=None,
            compile_trace_callback: Optional[Callable[[Any, str, Any], None]]
            = None) -> None:
        """
        :arg compile_trace_callback: A function of three arguments
            *(what, stage, ir)*, where *what* identifies the object
            being compiled, *stage* is a string describing the compilation
            pass, and *ir* is an object containing the intermediate
            representation. This interface should be considered
            unstable.
        """
        if allocator is None:
            warn("No memory allocator specified, please pass one. "
                 "(Preferably a pyopencl.tools.MemoryPool in order "
                 "to reduce device allocations)")

        super().__init__(queue, allocator,
                compile_trace_callback=compile_trace_callback)

        self.mpi_communicator = mpi_communicator
        self.mpi_base_tag = mpi_base_tag
```