### PR TITLE
Fix `_get_single_grid_pytato_actx_class`

### DIFF
--- a/grudge/array_context.py
+++ b/grudge/array_context.py
@@ -530,16 +530,15 @@ def _get_single_grid_pytato_actx_class(distributed: bool) -> Type[ArrayContext]:
     # lazy, non-distributed
     if not distributed:
         if _HAVE_SINGLE_GRID_WORK_BALANCING:
-            actx_class = SingleGridWorkBalancingPytatoArrayContext
+            return SingleGridWorkBalancingPytatoArrayContext
         else:
-            actx_class = PytatoPyOpenCLArrayContext
-    # distributed+lazy:
-    if _HAVE_SINGLE_GRID_WORK_BALANCING:
-        actx_class = MPISingleGridWorkBalancingPytatoArrayContext
+            return PytatoPyOpenCLArrayContext
     else:
-        actx_class = MPIBasePytatoPyOpenCLArrayContext
-
-    return actx_class
+        # distributed+lazy:
+        if _HAVE_SINGLE_GRID_WORK_BALANCING:
+            return MPISingleGridWorkBalancingPytatoArrayContext
+        else:
+            return MPIBasePytatoPyOpenCLArrayContext
 
 
 def get_reasonable_array_context_class(


### PR DESCRIPTION
Without this, `wave-lazy.py --lazy` in mirgecom is broken:

https://github.com/inducer/arraycontext/actions/runs/3133078673/jobs/5086073780#step:3:6773

(in tunr breaking upstream CI, as shown)