### PR TITLE
Update mirgecom downstream testing to use integrated test runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,12 @@ jobs:
                 build_py_project_in_conda_env
 
                 if test "$DOWNSTREAM_PROJECT" = "mirgecom"; then
-                    # Test main branch
-                    # Only test examples, not pytest tests, as those take too much time.
-                    examples/run_examples.sh ./examples
+                    # Test main (and production) branch
+                    # --all:
+                    # Examples - runs mirgecom examples
+                    # LazyAccuracy - checks lazy vs. eager numerical results
+                    # Production - runs mirgecom's production/prediction tests
+                    scripts/run_integrated_tests.sh --all
                 else
                     test_py_project
                 fi


### PR DESCRIPTION
Use mirgecom integrated test runner to run lazy, examples, and production testing.  Plugs a production testing hole.