### PR TITLE
Require pocl>=3.1 for improved SVM support

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -6,7 +6,8 @@ dependencies:
 - git
 - numpy
 - libhwloc=2
-- pocl
+# pocl 3.1 needed for SVM functionality
+- pocl>=3.1
 - islpy
 - pyopencl
 - python=3


### PR DESCRIPTION
Conda started finding solutions with pocl 1.3 for reasons I wasn't able to discover.

e.g. https://github.com/inducer/meshmode/actions/runs/6211644674/job/16861042998?pr=388