### PR TITLE
Remove redundant constant handling in `project()`

### DIFF
--- a/grudge/projection.py
+++ b/grudge/projection.py
@@ -43,8 +43,6 @@ from grudge.dof_desc import (
     BoundaryDomainTag,
     ConvertibleToDOFDesc)
 
-from numbers import Number
-
 
 def project(
         dcoll: DiscretizationCollection,
@@ -78,7 +76,7 @@ def project(
 
     # }}}
 
-    if isinstance(vec, Number) or src_dofdesc == tgt_dofdesc:
+    if src_dofdesc == tgt_dofdesc:
         return vec
 
     return dcoll.connection_from_dds(src_dofdesc, tgt_dofdesc)(vec)


### PR DESCRIPTION
Handled in meshmode as of https://github.com/inducer/meshmode/pull/398, so no longer needed here.