### PR TITLE
Fix surface advection example

### DIFF
--- a/examples/advection/surface.py
+++ b/examples/advection/surface.py
@@ -214,7 +214,7 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False):
     logger.info("nsteps:    %d", nsteps)
 
     from grudge.shortcuts import set_up_rk4
-    dt_stepper = set_up_rk4("u", dt, u0, rhs)
+    dt_stepper = set_up_rk4("u", float(dt), u0, rhs)
     plot = Plotter(actx, dcoll, order, visualize=visualize)
 
     norm_u = actx.to_numpy(op.norm(dcoll, u0, 2))

--- a/examples/advection/var-velocity.py
+++ b/examples/advection/var-velocity.py
@@ -200,7 +200,7 @@ def main(ctx_factory, dim=2, order=4, use_quad=False, visualize=False,
     # {{{ time stepping
 
     from grudge.shortcuts import set_up_rk4
-    dt_stepper = set_up_rk4("u", dt, u, rhs)
+    dt_stepper = set_up_rk4("u", float(dt), u, rhs)
     plot = Plotter(actx, dcoll, order, visualize=visualize,
             ylim=[-0.1, 1.1])
 

--- a/examples/advection/weak.py
+++ b/examples/advection/weak.py
@@ -172,7 +172,7 @@ def main(ctx_factory, dim=2, order=4, visualize=False):
     # {{{ time stepping
 
     from grudge.shortcuts import set_up_rk4
-    dt_stepper = set_up_rk4("u", dt, u, rhs)
+    dt_stepper = set_up_rk4("u", float(dt), u, rhs)
     plot = Plotter(actx, dcoll, order, visualize=visualize,
             ylim=[-1.1, 1.1])
 


### PR DESCRIPTION
The changes to `DOFArray` in https://github.com/inducer/meshmode/pull/421 seem to have slightly broken this example: when doing `dt * rhs`, dt was a `np.array(1.0)` and rhs was `DOFArray` and it wouldn't broadcast that anymore.