### PR TITLE
Enable `force_device_scalars` by default

### DIFF
--- a/grudge/array_context.py
+++ b/grudge/array_context.py
@@ -128,7 +128,7 @@ class PyOpenCLArrayContext(_PyOpenCLArrayContextBase):
     def __init__(self, queue: "pyopencl.CommandQueue",
             allocator: Optional["pyopencl.tools.AllocatorBase"] = None,
             wait_event_queue_length: Optional[int] = None,
-            force_device_scalars: bool = False) -> None:
+            force_device_scalars: bool = True) -> None:
 
         if allocator is None:
             warn("No memory allocator specified, please pass one. "
@@ -446,7 +446,7 @@ class MPIPyOpenCLArrayContext(PyOpenCLArrayContext, MPIBasedArrayContext):
             queue: "pyopencl.CommandQueue",
             *, allocator: Optional["pyopencl.tools.AllocatorBase"] = None,
             wait_event_queue_length: Optional[int] = None,
-            force_device_scalars: bool = False) -> None:
+            force_device_scalars: bool = True) -> None:
         """
         See :class:`arraycontext.impl.pyopencl.PyOpenCLArrayContext` for most
         arguments.
@@ -533,13 +533,6 @@ class PytestPytatoPyOpenCLArrayContextFactory(
         alloc = MemoryPool(ImmediateAllocator(queue))
 
         return self.actx_class(queue, allocator=alloc)
-
-
-# deprecated
-class PytestPyOpenCLArrayContextFactoryWithHostScalars(
-        _PytestPyOpenCLArrayContextFactoryWithClass):
-    actx_class = PyOpenCLArrayContext
-    force_device_scalars = False
 
 
 register_pytest_array_context_factory("grudge.pyopencl",


### PR DESCRIPTION
Instances of `PyOpenCLArrayContext` that don't explicitly pass `force_device_scalars=True` will have it set to `False`. This is deprecated, and will be an error once inducer/arraycontext#278 goes in.

After the arraycontext PR gets merged I'll submit a follow-up here that makes the interface for `force_device_scalars` match (i.e., allow it to be `None`), so that it will only emit deprecation warnings when explicitly specified.