### PR TITLE
Get MPI communicator from array context instead of `dcoll`

### DIFF
--- a/grudge/trace_pair.py
+++ b/grudge/trace_pair.py
@@ -410,7 +410,7 @@ class _RankBoundaryCommunicationEager:
         bdry_dd = volume_dd.trace(BTAG_PARTITION(remote_rank))
 
         local_bdry_data = project(dcoll, volume_dd, bdry_dd, array_container)
-        comm = dcoll.mpi_communicator
+        comm = actx.mpi_communicator
         assert comm is not None
 
         self.dcoll = dcoll


### PR DESCRIPTION
`dcoll.mpi_communicator` is deprecated.

Note: Can't remove `dcoll.mpi_communicator` yet, because https://github.com/inducer/grudge/pull/285 still needs it.