### PR TITLE
Use arguments in `WarpedRectMeshBuilder` when generating the mesh

### DIFF
--- a/test/mesh_data.py
+++ b/test/mesh_data.py
@@ -147,4 +147,4 @@ class WarpedRectMeshBuilder(MeshBuilder):
 
     def get_mesh(self, resolution, mesh_order=4):
         return mgen.generate_warped_rect_mesh(
-                dim=self.dim, order=4, nelements_side=6)
+                dim=self.dim, order=mesh_order, nelements_side=resolution)


### PR DESCRIPTION
The builder only uses the dim argument passed to it when generating the mesh despite having an attribute for default mesh resolutions to use.

An example where this builder is used is in `test_grudge.test_mass_operator_inverse`: https://github.com/inducer/grudge/blob/cc954d0cef476187ab478522a4d091a2fb3ec804/test/test_grudge.py#L250-L251

https://github.com/inducer/grudge/blob/cc954d0cef476187ab478522a4d091a2fb3ec804/test/test_grudge.py#L276-L277

Default resolutions for the builder are here: https://github.com/inducer/grudge/blob/cc954d0cef476187ab478522a4d091a2fb3ec804/test/mesh_data.py#L142-L150. 

Convergence tests aren't done for the inverse mass test in main (or else it would likely fail). Still, not using arguments seems to be unintended.

This PR changes the builder to use the arguments passed to it when generating the mesh.