### PR TITLE
Update references in docs

### DIFF
--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -50,8 +50,8 @@ Next time you want to use `grudge`, just run the following command::
 
 You may also like to add this to a startup file (like :file:`$HOME/.bashrc`) or create an alias for it.
 
-After this, you should be able to run the `tests <https://gitlab.tiker.net/inducer/grudge/tree/master/test>`_
-or `examples <https://gitlab.tiker.net/inducer/grudge/tree/master/examples>`_.
+After this, you should be able to run the `tests <https://gitlab.tiker.net/inducer/grudge/tree/main/test>`_
+or `examples <https://gitlab.tiker.net/inducer/grudge/tree/main/examples>`_.
 
 Troubleshooting the Installation
 --------------------------------

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -5,18 +5,18 @@ References
     When adding references here, please use the demonstrated format:
     [FirstAuthor_pubyear]
 
-.. [Shewchuk_2002] J. R. Shewchuk (2002), \
-    What Is a Good Linear Finite Element? - \
-    Interpolation, Conditioning, Anisotropy, and Quality Measures, \
-    In Proc. of the 11th International Meshing Roundtable \
-    `(link) <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.19.2164>`__
+.. [Shewchuk_2002] J. R. Shewchuk (2002),
+    *What Is a Good Linear Element? - Interpolation, Conditioning, Quality Measures*,
+    In Proceedings of the 11th International Meshing Roundtable.
+    `(link) <https://hal.science/hal-04614934/>`__
+    `(slides) <https://people.eecs.berkeley.edu/~jrs/papers/elemtalk.pdf>`__
 
-.. [Hesthaven_2008] J. S. Hesthaven and T. Warburton (2008), \
-    Nodal Discontinuous Galerkin Methods: Algorithms, Analysis, and Applications, \
-    Springer \
+.. [Hesthaven_2008] J. S. Hesthaven and T. Warburton (2008),
+    *Nodal Discontinuous Galerkin Methods: Algorithms, Analysis, and Applications*,
+    Springer.
     `(doi) <https://doi.org/10.1007/978-0-387-72067-8>`__
 
-.. [Chan_2016] J. Chan, R. J. Hewett, and T. Warburton (2016), \
-    Weight-Adjusted Discontinuous Galerkin Methods: Curvilinear Meshes, \
-    SIAM J Sci Comput \
+.. [Chan_2016] J. Chan, R. J. Hewett, and T. Warburton (2016),
+    *Weight-Adjusted Discontinuous Galerkin Methods: Curvilinear Meshes*,
+    SIAM Journal on Scientific Computing.
     `(doi) <https://doi.org/10.1137/16M1089198>`__


### PR DESCRIPTION
This updates for formatting in `references.rst` a bit (mostly inspired by typos complaining about "SIAM J Sci Comput") and fixes some out of date URLs.