### PR TITLE
Stop passing unevaluated args to actx.compiled functions

### DIFF
--- a/examples/euler/acoustic_pulse.py
+++ b/examples/euler/acoustic_pulse.py
@@ -36,7 +36,7 @@ from pytools.obj_array import make_obj_array
 import grudge.op as op
 from grudge.array_context import PyOpenCLArrayContext, PytatoPyOpenCLArrayContext
 from grudge.models.euler import ConservedEulerField, EulerOperator, InviscidWallBC
-from grudge.shortcuts import rk4_step
+from grudge.shortcuts import compiled_lsrk45_step
 
 
 logger = logging.getLogger(__name__)
@@ -200,7 +200,7 @@ def run_acoustic_pulse(actx,
             assert norm_q < 5
 
         fields = actx.thaw(actx.freeze(fields))
-        fields = rk4_step(fields, t, dt, compiled_rhs)
+        fields = compiled_lsrk45_step(actx, fields, t, dt, compiled_rhs)
         t += dt
         step += 1
 

--- a/examples/euler/vortex.py
+++ b/examples/euler/vortex.py
@@ -31,7 +31,7 @@ import pyopencl.tools as cl_tools
 import grudge.op as op
 from grudge.array_context import PyOpenCLArrayContext, PytatoPyOpenCLArrayContext
 from grudge.models.euler import EulerOperator, vortex_initial_condition
-from grudge.shortcuts import rk4_step
+from grudge.shortcuts import compiled_lsrk45_step
 
 
 logger = logging.getLogger(__name__)
@@ -126,6 +126,8 @@ def run_vortex(actx, order=3, resolution=8, final_time=5,
 
     vis = make_visualizer(dcoll)
 
+    fields = actx.freeze_thaw(fields)
+
     # {{{ time stepping
 
     step = 0
@@ -146,8 +148,7 @@ def run_vortex(actx, order=3, resolution=8, final_time=5,
                 )
             assert norm_q < 200
 
-        fields = actx.thaw(actx.freeze(fields))
-        fields = rk4_step(fields, t, dt, compiled_rhs)
+        fields = compiled_lsrk45_step(actx, fields, t, dt, compiled_rhs)
         t += dt
         step += 1
 

--- a/examples/wave/wave-op-mpi.py
+++ b/examples/wave/wave-op-mpi.py
@@ -277,6 +277,8 @@ def main(ctx_factory, dim=2, order=3,
     import time
     start = time.time()
 
+    fields = actx.freeze_thaw(fields)
+
     t = 0
     t_final = 3
     istep = 0


### PR DESCRIPTION
Made necessary by https://github.com/inducer/arraycontext/pull/305, see https://github.com/inducer/arraycontext/pull/305#issuecomment-2759225212.

Needs:

- [x] https://github.com/inducer/arraycontext/pull/310
- [x] Revert `requirements.txt`